### PR TITLE
readme.md:include info about maps from previous commit

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,7 @@
+2022-10-25
+
+    * skirmishes/{a_path_beyond_ii_8p , x_8p}: add new maps by @Grapjas93
+
 2022-10-24
 
     * random/carpathian.js:replace with newer version

--- a/readme.md
+++ b/readme.md
@@ -42,7 +42,9 @@ of this repo.
 
 | Map Name | Author | Link | Publication Date |
 |----------|--------|------|------------------|
-| Conquest of Hispania | perfecto25 | | 2022-10-17 
+| A Path Beyond II | Grapjas93 | | 2022-10-25
+| X | [Grapjas93](https://github.com/Grapjas93) | | 2022-10-25
+| Conquest of Hispania | perfecto25 | | 2022-10-17
 | The Valley of Forgotten Temple | [Lion.Kanzen](https://wildfiregames.com/forum/profile/13202-lionkanzen/) | [Forum](https://wildfiregames.com/forum/topic/81151-skirmish-map-valley-of-forgotten-temple-01-4-players-map/) | 2022-05-23 |
 | Chess | [Jammyjamjamman](https://wildfiregames.com/forum/profile/33845-jammyjamjamman/) | [Forum](https://wildfiregames.com/forum/topic/61013-chess-map/) | 2021-10-23 |
 | Cliffs of Carnage|[andy5995](https://wildfiregames.com/forum/profile/21632-andy5995/)|[Forum](https://wildfiregames.com/forum/topic/30590-cliffs-of-carnage-new-4v4-pvp-map/)|2020-10-02|


### PR DESCRIPTION
These maps were included by @Grapjas93 in
https://github.com/0ad-matters/community-maps-2/commit/98320b5bd5130b73f976bc2bcfa3784ad996eb2d

The date can be changed to reflect when the maps first became public. And the forum field link can be added if you have a forum post for them.