### PR TITLE
fix: Athenian theatron and Carthaginian market prop

### DIFF
--- a/maps/scenarios/Cyzicus.xml
+++ b/maps/scenarios/Cyzicus.xml
@@ -2411,7 +2411,7 @@
 			<Actor seed="39018"/>
 		</Entity>
 		<Entity uid="400">
-			<Template>structures/athen/theatron</Template>
+			<Template>structures/athen/theater</Template>
 			<Player>3</Player>
 			<Position x="731.22248" z="1265.80542"/>
 			<Orientation y="-5.5225"/>

--- a/maps/scenarios/siege_of_greece.xml
+++ b/maps/scenarios/siege_of_greece.xml
@@ -4471,7 +4471,7 @@
 			<Actor seed="56556"/>
 		</Entity>
 		<Entity uid="709">
-			<Template>structures/athen/theatron</Template>
+			<Template>structures/athen/theater</Template>
 			<Player>1</Player>
 			<Position x="993.51587" z="835.64216"/>
 			<Orientation y="4.72925"/>
@@ -24051,7 +24051,7 @@
 			<Actor seed="6554"/>
 		</Entity>
 		<Entity uid="5470">
-			<Template>actor|props/structures/carthaginians/market.xml</Template>
+			<Template>actor|props/structures/carthaginians/market_old.xml</Template>
 			<Position x="1011.6236" z="737.28864"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="56710"/>


### PR DESCRIPTION
Ref: #18

### Description
- Carthaginian market prop was renamed
  - [rP19130](https://code.wildfiregames.com/rP19130)
- Fix Athenian theatron
  - [rP23347](https://code.wildfiregames.com/rP23347)
  	- from: `structures/athen_theatron`
	- to: `structures/athen_theater`
  - [rP24216](https://code.wildfiregames.com/rP24216)
    - from: `structures/athen_theater`
	- to: `structures/athen/theater`
