### PR TITLE
fix: wall_medium hero elephant_stable

### DIFF
--- a/maps/scenarios/At World's End.xml
+++ b/maps/scenarios/At World's End.xml
@@ -9170,7 +9170,7 @@
 			<Actor seed="8158"/>
 		</Entity>
 		<Entity uid="2184">
-			<Template>structures/maur/elephant_stables</Template>
+			<Template>structures/maur/elephant_stable</Template>
 			<Player>3</Player>
 			<Position x="461.1297" z="156.08242"/>
 			<Orientation y="-0.33893"/>
@@ -9395,7 +9395,7 @@
 			<Actor seed="62716"/>
 		</Entity>
 		<Entity uid="2259">
-			<Template>structures/maur/wall</Template>
+			<Template>structures/maur/wall_medium</Template>
 			<Player>3</Player>
 			<Position x="521.07508" z="158.31618"/>
 			<Orientation y="0.49708"/>
@@ -9403,7 +9403,7 @@
 			<Actor seed="50540"/>
 		</Entity>
 		<Entity uid="2260">
-			<Template>structures/maur/wall</Template>
+			<Template>structures/maur/wall_medium</Template>
 			<Player>3</Player>
 			<Position x="541.63904" z="146.9408"/>
 			<Orientation y="-2.63186"/>
@@ -32742,7 +32742,7 @@
 			<Actor seed="11834"/>
 		</Entity>
 		<Entity uid="6494">
-			<Template>units/maur/hero_maurya</Template>
+			<Template>units/maur/hero_chandragupta</Template>
 			<Player>3</Player>
 			<Position x="733.19239" z="164.76838"/>
 			<Orientation y="-0.46518"/>
@@ -32889,7 +32889,7 @@
 			<Actor seed="20800"/>
 		</Entity>
 		<Entity uid="6515">
-			<Template>units/maur/hero_maurya</Template>
+			<Template>units/maur/hero_chandragupta</Template>
 			<Player>4</Player>
 			<Position x="888.18622" z="456.74503"/>
 			<Orientation y="2.35621"/>
@@ -32987,7 +32987,7 @@
 			<Actor seed="27342"/>
 		</Entity>
 		<Entity uid="6529">
-			<Template>units/maur/hero_maurya</Template>
+			<Template>units/maur/hero_chandragupta</Template>
 			<Player>4</Player>
 			<Position x="727.56043" z="548.32172"/>
 			<Orientation y="-0.81112"/>

--- a/maps/scenarios/First Battle of Numantia.xml
+++ b/maps/scenarios/First Battle of Numantia.xml
@@ -596,7 +596,7 @@
 			<Actor seed="60444"/>
 		</Entity>
 		<Entity uid="273">
-			<Template>structures/iber/wall</Template>
+			<Template>structures/iber/wall_medium</Template>
 			<Player>1</Player>
 			<Position x="585.12616" z="775.1482"/>
 			<Orientation y="-2.15067"/>
@@ -604,7 +604,7 @@
 			<Actor seed="43616"/>
 		</Entity>
 		<Entity uid="274">
-			<Template>structures/iber/wall</Template>
+			<Template>structures/iber/wall_medium</Template>
 			<Player>1</Player>
 			<Position x="539.01075" z="784.35492"/>
 			<Orientation y="-3.38833"/>
@@ -612,7 +612,7 @@
 			<Actor seed="8731"/>
 		</Entity>
 		<Entity uid="275">
-			<Template>structures/iber/wall</Template>
+			<Template>structures/iber/wall_medium</Template>
 			<Player>1</Player>
 			<Position x="599.98261" z="749.3653"/>
 			<Orientation y="1.20899"/>
@@ -620,7 +620,7 @@
 			<Actor seed="4452"/>
 		</Entity>
 		<Entity uid="276">
-			<Template>structures/iber/wall</Template>
+			<Template>structures/iber/wall_medium</Template>
 			<Player>1</Player>
 			<Position x="604.74305" z="721.64496"/>
 			<Orientation y="1.53226"/>

--- a/maps/scenarios/Siege of Numantia.xml
+++ b/maps/scenarios/Siege of Numantia.xml
@@ -638,7 +638,7 @@
 			<Actor seed="60444"/>
 		</Entity>
 		<Entity uid="273">
-			<Template>structures/iber/wall</Template>
+			<Template>structures/iber/wall_medium</Template>
 			<Player>1</Player>
 			<Position x="585.12616" z="775.1482"/>
 			<Orientation y="-2.15067"/>
@@ -646,7 +646,7 @@
 			<Actor seed="43616"/>
 		</Entity>
 		<Entity uid="274">
-			<Template>structures/iber/wall</Template>
+			<Template>structures/iber/wall_medium</Template>
 			<Player>1</Player>
 			<Position x="539.01075" z="784.35492"/>
 			<Orientation y="-3.38833"/>
@@ -654,7 +654,7 @@
 			<Actor seed="8731"/>
 		</Entity>
 		<Entity uid="275">
-			<Template>structures/iber/wall</Template>
+			<Template>structures/iber/wall_medium</Template>
 			<Player>1</Player>
 			<Position x="599.98261" z="749.3653"/>
 			<Orientation y="1.20899"/>
@@ -662,7 +662,7 @@
 			<Actor seed="4452"/>
 		</Entity>
 		<Entity uid="276">
-			<Template>structures/iber/wall</Template>
+			<Template>structures/iber/wall_medium</Template>
 			<Player>1</Player>
 			<Position x="604.74305" z="721.64496"/>
 			<Orientation y="1.53226"/>


### PR DESCRIPTION
Ref: #18

### Description
- rename Mauryan hero
  - [rP23834](https://code.wildfiregames.com/rP23834)
-  rename `elephant_stables` -> `elephant_stable`
  - [rP25053](https://code.wildfiregames.com/rP25053)
- replace `wall` templates with `wall_medium`
  - All the occurences of `<civ>/wall` template replaced with `<civ>/wall_medium` in the scenario maps as it seemed to be the visual actor the objects refered to.
  - [rP19448](https://code.wildfiregames.com/rP19448)
