### PR TITLE
fix: brit war dog and kennel

### DIFF
--- a/maps/scenarios/Brigantium (2).xml
+++ b/maps/scenarios/Brigantium (2).xml
@@ -20782,15 +20782,8 @@
 			<Orientation y="2.35621"/>
 			<Actor seed="31916"/>
 		</Entity>
-		<Entity uid="3603">
-			<Template>structures/brit/kennel</Template>
-			<Player>1</Player>
-			<Position x="1669.0741" z="843.5152"/>
-			<Orientation y="-1.6029"/>
-			<Actor seed="10036"/>
-		</Entity>
 		<Entity uid="3604">
-			<Template>units/brit/war_dog_b</Template>
+			<Template>units/brit/war_dog</Template>
 			<Player>1</Player>
 			<Position x="1662.51368" z="841.33002"/>
 			<Orientation y="-2.30988"/>

--- a/maps/scenarios/raiders_in_the_alps.xml
+++ b/maps/scenarios/raiders_in_the_alps.xml
@@ -14982,14 +14982,14 @@
 			<Actor seed="35176"/>
 		</Entity>
 		<Entity uid="2466">
-			<Template>units/brit/war_dog_b</Template>
+			<Template>units/brit/war_dog</Template>
 			<Player>3</Player>
 			<Position x="584.18891" z="37.85616"/>
 			<Orientation y="6.74958"/>
 			<Actor seed="27413"/>
 		</Entity>
 		<Entity uid="2468">
-			<Template>units/brit/war_dog_e</Template>
+			<Template>units/brit/war_dog</Template>
 			<Player>3</Player>
 			<Position x="578.61109" z="41.09609"/>
 			<Orientation y="6.71937"/>
@@ -15175,13 +15175,6 @@
 			<Position x="611.64197" z="81.71737"/>
 			<Orientation y="7.43456"/>
 			<Actor seed="6785"/>
-		</Entity>
-		<Entity uid="2518">
-			<Template>structures/brit/kennel</Template>
-			<Player>3</Player>
-			<Position x="567.45966" z="22.77407"/>
-			<Orientation y="0.19094"/>
-			<Actor seed="48004"/>
 		</Entity>
 		<Entity uid="2519">
 			<Template>structures/brit/market</Template>


### PR DESCRIPTION
Ref: #18

### Description
- rename Briton war dog
  - [rP23893](https://code.wildfiregames.com/rP23893)
- the kennel was removed from the template, but is still available as a prop
  - [rP23781](https://code.wildfiregames.com/rP23781)
  - I decided to remove it as well, since renaming it to an actor prop would make it unusable for the player.
    - `actor|structures/britons/kennel.xml`
