### PR TITLE
fix: champion_infantry_barracks

### DIFF
--- a/maps/scenarios/Qart Hadasht.xml
+++ b/maps/scenarios/Qart Hadasht.xml
@@ -17208,125 +17208,125 @@
 			<Actor seed="33432"/>
 		</Entity>
 		<Entity uid="2894">
-			<Template>units/rome/champion_infantry_barracks</Template>
+			<Template>units/rome/champion_infantry_swordsman</Template>
 			<Player>1</Player>
 			<Position x="1413.89185" z="824.03864"/>
 			<Orientation y="-2.2163"/>
 			<Actor seed="4710"/>
 		</Entity>
 		<Entity uid="2895">
-			<Template>units/rome/champion_infantry_barracks</Template>
+			<Template>units/rome/champion_infantry_swordsman</Template>
 			<Player>1</Player>
 			<Position x="1411.12488" z="826.05884"/>
 			<Orientation y="-1.97545"/>
 			<Actor seed="39036"/>
 		</Entity>
 		<Entity uid="2896">
-			<Template>units/rome/champion_infantry_barracks</Template>
+			<Template>units/rome/champion_infantry_swordsman</Template>
 			<Player>1</Player>
 			<Position x="1407.74305" z="828.24433"/>
 			<Orientation y="-1.93808"/>
 			<Actor seed="6166"/>
 		</Entity>
 		<Entity uid="2897">
-			<Template>units/rome/champion_infantry_barracks</Template>
+			<Template>units/rome/champion_infantry_swordsman</Template>
 			<Player>1</Player>
 			<Position x="1404.24695" z="830.66065"/>
 			<Orientation y="-1.95324"/>
 			<Actor seed="60938"/>
 		</Entity>
 		<Entity uid="2898">
-			<Template>units/rome/champion_infantry_barracks</Template>
+			<Template>units/rome/champion_infantry_swordsman</Template>
 			<Player>1</Player>
 			<Position x="1416.14258" z="820.45246"/>
 			<Orientation y="-2.16106"/>
 			<Actor seed="20166"/>
 		</Entity>
 		<Entity uid="2899">
-			<Template>units/rome/champion_infantry_barracks</Template>
+			<Template>units/rome/champion_infantry_swordsman</Template>
 			<Player>1</Player>
 			<Position x="1409.24048" z="819.0146"/>
 			<Orientation y="-1.93093"/>
 			<Actor seed="25134"/>
 		</Entity>
 		<Entity uid="2900">
-			<Template>units/rome/champion_infantry_barracks</Template>
+			<Template>units/rome/champion_infantry_swordsman</Template>
 			<Player>1</Player>
 			<Position x="1406.70887" z="820.9618"/>
 			<Orientation y="-2.04578"/>
 			<Actor seed="28428"/>
 		</Entity>
 		<Entity uid="2901">
-			<Template>units/rome/champion_infantry_barracks</Template>
+			<Template>units/rome/champion_infantry_swordsman</Template>
 			<Player>1</Player>
 			<Position x="1403.95911" z="824.02918"/>
 			<Orientation y="-2.16532"/>
 			<Actor seed="15244"/>
 		</Entity>
 		<Entity uid="2902">
-			<Template>units/rome/champion_infantry_barracks</Template>
+			<Template>units/rome/champion_infantry_swordsman</Template>
 			<Player>1</Player>
 			<Position x="1400.86548" z="826.42786"/>
 			<Orientation y="-2.11747"/>
 			<Actor seed="9112"/>
 		</Entity>
 		<Entity uid="2904">
-			<Template>units/rome/champion_infantry_barracks</Template>
+			<Template>units/rome/champion_infantry_swordsman</Template>
 			<Player>1</Player>
 			<Position x="1412.11866" z="816.27894"/>
 			<Orientation y="-1.92734"/>
 			<Actor seed="36400"/>
 		</Entity>
 		<Entity uid="2905">
-			<Template>units/rome/champion_infantry_barracks</Template>
+			<Template>units/rome/champion_infantry_swordsman</Template>
 			<Player>1</Player>
 			<Position x="1419.60218" z="807.64136"/>
 			<Orientation y="-2.11748"/>
 		</Entity>
 		<Entity uid="2906">
-			<Template>units/rome/champion_infantry_barracks</Template>
+			<Template>units/rome/champion_infantry_swordsman</Template>
 			<Player>1</Player>
 			<Position x="1423.60499" z="804.29828"/>
 			<Orientation y="-2.16532"/>
 		</Entity>
 		<Entity uid="2907">
-			<Template>units/rome/champion_infantry_barracks</Template>
+			<Template>units/rome/champion_infantry_swordsman</Template>
 			<Player>1</Player>
 			<Position x="1426.35474" z="801.2309"/>
 			<Orientation y="-2.04578"/>
 		</Entity>
 		<Entity uid="2908">
-			<Template>units/rome/champion_infantry_barracks</Template>
+			<Template>units/rome/champion_infantry_swordsman</Template>
 			<Player>1</Player>
 			<Position x="1428.88636" z="799.2837"/>
 			<Orientation y="-1.93093"/>
 		</Entity>
 		<Entity uid="2909">
-			<Template>units/rome/champion_infantry_barracks</Template>
+			<Template>units/rome/champion_infantry_swordsman</Template>
 			<Player>1</Player>
 			<Position x="1436.39588" z="799.68287"/>
 			<Orientation y="-2.16106"/>
 		</Entity>
 		<Entity uid="2910">
-			<Template>units/rome/champion_infantry_barracks</Template>
+			<Template>units/rome/champion_infantry_swordsman</Template>
 			<Player>1</Player>
 			<Position x="1423.89283" z="810.92975"/>
 			<Orientation y="-1.95325"/>
 		</Entity>
 		<Entity uid="2911">
-			<Template>units/rome/champion_infantry_barracks</Template>
+			<Template>units/rome/champion_infantry_swordsman</Template>
 			<Player>1</Player>
 			<Position x="1427.38892" z="808.51343"/>
 			<Orientation y="-1.93808"/>
 		</Entity>
 		<Entity uid="2912">
-			<Template>units/rome/champion_infantry_barracks</Template>
+			<Template>units/rome/champion_infantry_swordsman</Template>
 			<Player>1</Player>
 			<Position x="1430.77076" z="806.32795"/>
 			<Orientation y="-1.97545"/>
 		</Entity>
 		<Entity uid="2913">
-			<Template>units/rome/champion_infantry_barracks</Template>
+			<Template>units/rome/champion_infantry_swordsman</Template>
 			<Player>1</Player>
 			<Position x="1433.53772" z="804.30774"/>
 			<Orientation y="-2.2163"/>
@@ -18250,7 +18250,7 @@
 			<Actor seed="48434"/>
 		</Entity>
 		<Entity uid="3092">
-			<Template>units/rome/champion_infantry_barracks</Template>
+			<Template>units/rome/champion_infantry_swordsman</Template>
 			<Player>1</Player>
 			<Position x="1432.0564" z="796.08039"/>
 			<Orientation y="-2.16106"/>


### PR DESCRIPTION
Ref: #18

### Description
- `units/rome/champion_infantry_barracks` was removed from the game
  - [rP24657](https://code.wildfiregames.com/rP24657)
  - `units/rome/champion_infantry_swordsman` seems to be most similar to the original intention of the author of the map

![12](https://user-images.githubusercontent.com/92653266/221384701-122af6fa-35d2-4f1c-88fe-6626bb91e9ce.png)

