### PR TITLE
fix: failed chicken

### DIFF
--- a/maps/scenarios/First Battle of Numantia.xml
+++ b/maps/scenarios/First Battle of Numantia.xml
@@ -12330,12 +12330,6 @@
 			<Orientation y="2.35621"/>
 			<Actor seed="60428"/>
 		</Entity>
-		<Entity uid="2368">
-			<Template>gaia/fauna_chicken</Template>
-			<Player>-1</Player>
-			<Position x="0" z="0"/>
-			<Orientation y="0"/>
-		</Entity>
 		<Entity uid="2464">
 			<Template>units/iber/cavalry_javelineer_b</Template>
 			<Player>1</Player>

--- a/maps/scenarios/Siege of Numantia.xml
+++ b/maps/scenarios/Siege of Numantia.xml
@@ -12497,12 +12497,6 @@
 			<Orientation y="2.35621"/>
 			<Actor seed="60428"/>
 		</Entity>
-		<Entity uid="2368">
-			<Template>gaia/fauna_chicken</Template>
-			<Player>-1</Player>
-			<Position x="0" z="0"/>
-			<Orientation y="0"/>
-		</Entity>
 		<Entity uid="2384">
 			<Template>units/rome/infantry_javelineer_e</Template>
 			<Player>2</Player>


### PR DESCRIPTION
Ref: #18

### Description
- the chicken in both files were incorrect, only `nonNegativeInteger` are allowed for the player
  - the scenario `relaxng` file is part of 0 A.D.
  - [binaries/data/mods/public/maps/scenario.rng](https://github.com/0ad/0ad/blob/master/binaries/data/mods/public/maps/scenario.rng#L226)


```rng
                    <data type="positiveInteger"/>
                  </attribute>
                  <element name="Template">
                    <text/>
                  </element>
                  <optional>
                    <element name="Player">
                      <data type="nonNegativeInteger"/>
                    </element>
                  </optional>
                  <element name="Position">
                    <ref name="pos_xz"/>
                  </element>
                  <element name="Orientation">
                    <attribute name="y">
                      <data type="decimal"/>
                    </attribute>
```

- to verify the integity of the sceneario maps, one can run this command


```sh
xmllint <PATH to the map> --relaxng <Path to scenario.rng> --noout
```

---

PS: In the old workflow of boonGUI certain `.rng` files were downloaded and tested against all relevant files.
[.github/workflows/code_quality.yml#L47](https://github.com/LangLangBart/boonGUI/blob/957dcabe82935d16e857ae03f51b1f8cc5829aaa/.github/workflows/code_quality.yml#L47)

```yml
      - name: Download rng
        run: |
          PREFIX="https://raw.githubusercontent.com/0ad/0ad/master/binaries/data/mods"
          wget "${PREFIX}"/public/art/actors/actor.rng
          wget "${PREFIX}"/mod/gui/gui.rng
          wget "${PREFIX}"/mod/gui/gui_page.rng
          wget "${PREFIX}"/public/art/materials/material.rng
          wget "${PREFIX}"/public/art/particles/particle.rng
          wget "${PREFIX}"/mod/audio/sound_group.rng
          wget "${PREFIX}"/public/simulation/data/territorymanager.rng
          wget "${PREFIX}"/public/art/textures/texture.rng
      - name: Install xmllint
        run: |
          sudo apt update
          sudo apt install --no-install-recommends -y libxml2-utils
      - name: Setup xmllint problem matcher
        # https://github.com/korelstar/xmllint-problem-matcher
        # https://github.com/korelstar/xmllint-problem-matcher/issues/5
        uses: korelstar/xmllint-problem-matcher@master
      - name: XML validating actors
        run: |
          find ./art/actors -name '*.xml' -print0 | while IFS= read -r -d '' file; do xmllint "$file" --relaxng ./actor.rng --noout; done
      - name: XML validating GUI files
        run: |
          find ./gui -name '*.xml' ! -name 'page_*.xml' -print0 | while IFS= read -r -d '' file; do xmllint "$file" --relaxng ./gui.rng --noout; done
          find ./gui -name 'page_*.xml' -print0 | while IFS= read -r -d '' file; do xmllint "$file" --relaxng ./gui_page.rng --noout; done
      - name: XML validating materials
        run: |
          find ./art/materials -name '*.xml' -print0 | while IFS= read -r -d '' file; do xmllint "$file" --relaxng ./material.rng --noout; done
      - name: XML validating particles
        run: |
          find ./art/particles -name '*.xml' -print0 | while IFS= read -r -d '' file; do xmllint "$file" --relaxng ./particle.rng --noout; done
      - name: XML validating soundgroups
        run: |
          find ./audio -name '*.xml' -print0 | while IFS= read -r -d '' file; do xmllint "$file" --relaxng ./sound_group.rng --noout; done
      - name: XML validating territorymanager
        run: |
          find ./simulation/data -name 'territorymanager.xml' -print0 | while IFS= read -r -d '' file; do xmllint "$file" --relaxng ./territorymanager.rng --noout; done
      - name: XML validating textures
        run: |
          find ./art/textures -name '*.xml' -print0 | while IFS= read -r -d '' file; do xmllint "$file" --relaxng ./texture.rng --noout; done
```

The files can be tested without the user having to load the map manually.

```sh
? Select a workflow run ✓ ci: add pre-commit.ci workflow, Servicing (main) 22h44m1s ago
? View a specific job in this run? ✓ Code Quality

✓ main Servicing · 4269283164
Triggered via push about 22 hours ago

✓ Code Quality in 1m42s (ID 11594592563)
  ✓ Set up job
  ✓ Pull ghcr.io/alstr/todo-to-issue-action:v4.10
  ✓ Build crate-ci/typos@v1.13.12
  ✓ Build errata-ai/vale-action@reviewdog
  ✓ Check out repository
  - Check out PR repository
  ✓ Typos check
  ✓ Vale Text Linter
  ✓ Download rng
  ✓ Install xmllint
  ✓ Setup xmllint problem matcher
  ✓ XML validating actors
  ✓ XML validating GUI files
  ✓ XML validating materials
  ✓ XML validating particles
  ✓ XML validating soundgroups
  ✓ XML validating territorymanager
  ✓ XML validating textures
  ✓ Set up Node.js
  ✓ Install dependencies
  ✓ ESLint & Prettier (XML)
  - Check ESLint PR contributors
  ✓ Check TODO issues
  ✓ Post Set up Node.js
  ✓ Post Check out repository
  ✓ Complete job
```
