### PR TITLE
fix: territory_pull

### DIFF
--- a/maps/scenarios/Qart Hadasht.xml
+++ b/maps/scenarios/Qart Hadasht.xml
@@ -11313,20 +11313,6 @@
 			<Orientation y="2.35621"/>
 			<Actor seed="20292"/>
 		</Entity>
-		<Entity uid="1936">
-			<Template>special/territory_pull</Template>
-			<Player>0</Player>
-			<Position x="0" z="0"/>
-			<Orientation y="2.35621"/>
-			<Actor seed="40102"/>
-		</Entity>
-		<Entity uid="1937">
-			<Template>special/territory_pull</Template>
-			<Player>0</Player>
-			<Position x="0" z="0"/>
-			<Orientation y="2.35621"/>
-			<Actor seed="61638"/>
-		</Entity>
 		<Entity uid="1938">
 			<Template>gaia/fauna_boar</Template>
 			<Player>0</Player>


### PR DESCRIPTION
Ref: #18

### Description
- the map `Qart Hadasht` was published by `tavius1994` in the [forum](https://wildfiregames.com/forum/topic/20976-new-map-qart-hadast-punic-carthagonova/) (17/Jul/16)
- the `territory_pull` object in its map is rarely used
  - the only occurance I could find is in 0 A.D.'s `scenarios/campaign_test_map.xml`

<img src="https://raw.githubusercontent.com/LangLangbart/ImagePool/814ab0d4e5f34fa5ce9ddf7ee4a6ad0517692e45/storage/2023-02-26_09-48-42_territory_pull.png" width="600">

- `territory_pulls`  were added with [rP9889](https://code.wildfiregames.com/rP9889)

---

#### Related

- IRC 0ad-dev: @philiptaylor [10/Mar/12](https://irclogs.wildfiregames.com/%230ad-dev/2012-03-10-QuakeNet-%230ad-dev.log)
```irc
17:38 < vtsj> Philip` -- do you know what the territory_pull and _block entities are used for?
17:44 < Philip`> For pulling and blocking territory
17:45 < Philip`> If you e.g. make a map with a river crossing it, with a bridge in the middle, and you want territories to stay primarily on one side of the river and not cross over to the other even if they're near the bridge, you could put a territory blocker in the middle of the bridge
17:46 < Philip`> or alternatively if you do want the territories to freely spread across both sides of the river, you could put territory puller objects across it, which allows the territory influence to go across
17:47 < Philip`> Basically they override the terrain-passability-dependent cost of expanding the territories
```

- IRC 0ad-dev: @sanderd17 [17/Jun/15](https://irclogs.wildfiregames.com/%230ad-dev/2015-06-17-QuakeNet-%230ad-dev.log)
```irc
12:30 < cc_1> sanderd17 and elexis
12:30 < cc_1> what is "special/territory_pull" supposed to be for ?
12:31 < sanderd17> to extend a player's territory
```

- Phabricator: @elexis1 [3/Apr/19](https://code.wildfiregames.com/D1798#73886)
```txt
[...]
I managed to test the entity in Atlas by dragging the waypoint flags around and seeing that it modifies the territory.

So it's an interesting gameplay element, it allows the map author to change the relevance of certain areas of the map, even though it doesn't provide a mechanism to communicate that to the player.[...]
```

<img src="https://raw.githubusercontent.com/LangLangbart/ImagePool/82d39222267470d6851f6d99be73e9108851f553/storage/2023-02-26_10-15-04_territory_pull.gif" width="600">

---

- based on the location of those `territory_pulls` in `tavius1994's` map and that he seems to only have posted one map, I assume it might have been a mistake by him.

```xml
		<Entity uid="1936">
			<Template>special/territory_pull</Template>
			<Player>0</Player>
			<Position x="0" z="0"/>
			<Orientation y="2.35621"/>
			<Actor seed="40102"/>
		</Entity>
		<Entity uid="1937">
			<Template>special/territory_pull</Template>
			<Player>0</Player>
			<Position x="0" z="0"/>
			<Orientation y="2.35621"/>
			<Actor seed="61638"/>
		</Entity>
```

- I decided to remove the `territory_pulls` from the map, the alternative is to rename it
  - [rP22266](https://code.wildfiregames.com/rP22266)
    - from: `special/territory_pull`
    - to: `territory_pulls/territory_pull_30`
