### PR TITLE
fix: update file name checker to account for space issue

### DIFF
--- a/.github/workflows/checkrefs.yml
+++ b/.github/workflows/checkrefs.yml
@@ -38,9 +38,19 @@ jobs:
           echo $LOG_CONTENTS
           exit 1
 
-      - uses: jitterbit/get-changed-files@v1
-      - run: |
-          for file in ${{ steps.files.outputs.all }}; do
+      - uses: tj-actions/changed-files@v35
+        id: changed-files
+        with:
+          separator: ","
+      - name: Check changed file names
+        run: |
+          IFS=$',' read -a changed_file_array <<< "${{ steps.changed-files.outputs.all_changed_files }}"
+          wrong_file_array=()
+          for file in "${changed_file_array[@]}"; do
             [[ "$file" =~ ^maps/(random|scenarios|skirmishes)/[^/]+$ ]] || continue
-            [[ $(basename "${file%.*}") =~ ^[0-9a-z_]+$ ]] || exit 1
+            [[ $(basename "${file%.*}") =~ ^[0-9a-z_]+$ ]] || wrong_file_array+=("$file")
           done
+          if [ ${#wrong_file_array[@]} -gt 0 ]; then
+            echo "::error:: Regex for file names doesn't match: ${wrong_file_array[@]} "
+            exit 1
+          fi

--- a/.github/workflows/checkrefs.yml
+++ b/.github/workflows/checkrefs.yml
@@ -37,20 +37,20 @@ jobs:
           fi
           echo $LOG_CONTENTS
           exit 1
-
       - uses: tj-actions/changed-files@v35
-        id: changed-files
+        id: changed-files-glob
         with:
-          separator: ","
+          separator: ','
+          files: |
+            **/maps/{random,skirmishes,scenarios}/*.{js,json,pmp,xml}
       - name: Check changed file names
-        run: |
-          IFS=$',' read -a changed_file_array <<< "${{ steps.changed-files.outputs.all_changed_files }}"
-          wrong_file_array=()
-          for file in "${changed_file_array[@]}"; do
-            [[ "$file" =~ ^maps/(random|scenarios|skirmishes)/[^/]+$ ]] || continue
-            [[ $(basename "${file%.*}") =~ ^[0-9a-z_]+$ ]] || wrong_file_array+=("$file")
+        run: |-
+          IFS=$',' read -ra filesArray <<< "${{ steps.changed-files-glob.outputs.all_changed_files }}"
+          errorFiles=()
+          for file in "${filesArray[@]}"; do
+            [[ $(basename "${file%.*}") =~ ^[0-9a-z_]+[0-9a-z]$ ]] || errorFiles+=("$file")
           done
-          if [ ${#wrong_file_array[@]} -gt 0 ]; then
-            echo "::error:: Regex for file names doesn't match: ${wrong_file_array[@]} "
+          if [ ${#errorFiles[@]} -gt 0 ]; then
+            echo "::error:: Regex for file names doesn't match: ${errorFiles[@]}"
             exit 1
           fi


### PR DESCRIPTION
#### Description

- Update to #110
- the `jitterbit/get-changed-files` repo is a bit outdated
  - the github workflow throws some warnings to consider changes on the runner
- Update to `tj-actions/changed-files`
  -  Fix bug when filenames contain spaces https://github.com/tj-actions/changed-files/issues/216
