### PR TITLE
fix: entities commonly associated with Gaia should not be owned by a player

### DIFF
--- a/maps/scenarios/at_worlds_end.xml
+++ b/maps/scenarios/at_worlds_end.xml
@@ -31633,42 +31633,42 @@
 		</Entity>
 		<Entity uid="6318">
 			<Template>gaia/fruit/berry_01</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="231.02799" z="661.92042"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="41398"/>
 		</Entity>
 		<Entity uid="6319">
 			<Template>gaia/fruit/berry_01</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="217.83616" z="666.16376"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="51884"/>
 		</Entity>
 		<Entity uid="6320">
 			<Template>gaia/fruit/berry_01</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="398.3491" z="413.56281"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="12866"/>
 		</Entity>
 		<Entity uid="6321">
 			<Template>gaia/fruit/berry_01</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="400.34339" z="418.12323"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="6646"/>
 		</Entity>
 		<Entity uid="6322">
 			<Template>gaia/fruit/berry_01</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="760.75165" z="851.76984"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="13782"/>
 		</Entity>
 		<Entity uid="6323">
 			<Template>gaia/fruit/berry_01</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="763.51911" z="857.02698"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="24108"/>

--- a/maps/scenarios/brigantium_2.xml
+++ b/maps/scenarios/brigantium_2.xml
@@ -3378,7 +3378,7 @@
 		</Entity>
 		<Entity uid="495">
 			<Template>gaia/tree/aleppo_pine</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="1693.35364" z="872.26752"/>
 			<Orientation y="2.96392"/>
 			<Actor seed="10310"/>
@@ -16731,308 +16731,308 @@
 		</Entity>
 		<Entity uid="2551">
 			<Template>gaia/treasure/food_barrels_buried</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="1090.80726" z="893.99512"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="6958"/>
 		</Entity>
 		<Entity uid="2554">
 			<Template>gaia/treasure/shipwreck_ram_bow</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="557.41083" z="1114.60962"/>
 			<Orientation y="-1.12935"/>
 			<Actor seed="260"/>
 		</Entity>
 		<Entity uid="2555">
 			<Template>gaia/treasure/shipwreck_debris</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="552.68964" z="1129.96338"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="56142"/>
 		</Entity>
 		<Entity uid="2564">
 			<Template>gaia/fish/generic</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="1276.4043" z="587.84089"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="38536"/>
 		</Entity>
 		<Entity uid="2565">
 			<Template>gaia/fish/generic</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="1393.20252" z="502.17087"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="21478"/>
 		</Entity>
 		<Entity uid="2566">
 			<Template>gaia/fish/generic</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="1317.57227" z="610.50379"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="6780"/>
 		</Entity>
 		<Entity uid="2567">
 			<Template>gaia/fish/generic</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="1318.23975" z="285.12336"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="42132"/>
 		</Entity>
 		<Entity uid="2568">
 			<Template>gaia/fish/generic</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="1456.50916" z="298.1211"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="24352"/>
 		</Entity>
 		<Entity uid="2569">
 			<Template>gaia/fish/generic</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="1370.91785" z="227.40006"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="52700"/>
 		</Entity>
 		<Entity uid="2570">
 			<Template>gaia/fish/generic</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="1327.81836" z="257.32844"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="11236"/>
 		</Entity>
 		<Entity uid="2571">
 			<Template>gaia/fish/generic</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="1342.05066" z="256.92042"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="766"/>
 		</Entity>
 		<Entity uid="2572">
 			<Template>gaia/fish/generic</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="1463.33985" z="237.14963"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="23166"/>
 		</Entity>
 		<Entity uid="2573">
 			<Template>gaia/fish/generic</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="1248.07105" z="203.39133"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="11376"/>
 		</Entity>
 		<Entity uid="2574">
 			<Template>gaia/fish/generic</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="1069.07679" z="111.11884"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="24730"/>
 		</Entity>
 		<Entity uid="2575">
 			<Template>gaia/fish/generic</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="883.00293" z="183.23285"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="44028"/>
 		</Entity>
 		<Entity uid="2576">
 			<Template>gaia/fish/generic</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="726.41285" z="138.3863"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="57498"/>
 		</Entity>
 		<Entity uid="2577">
 			<Template>gaia/fish/generic</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="712.26148" z="168.5185"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="4960"/>
 		</Entity>
 		<Entity uid="2578">
 			<Template>gaia/fish/generic</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="738.81952" z="252.4527"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="19082"/>
 		</Entity>
 		<Entity uid="2579">
 			<Template>gaia/fish/generic</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="735.91633" z="306.12586"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="62064"/>
 		</Entity>
 		<Entity uid="2580">
 			<Template>gaia/fish/generic</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="401.80881" z="225.07444"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="24296"/>
 		</Entity>
 		<Entity uid="2581">
 			<Template>gaia/fish/generic</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="310.92826" z="443.46198"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="34790"/>
 		</Entity>
 		<Entity uid="2582">
 			<Template>gaia/fish/generic</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="324.65357" z="458.27491"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="28962"/>
 		</Entity>
 		<Entity uid="2583">
 			<Template>gaia/fish/generic</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="343.214" z="452.3856"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="64178"/>
 		</Entity>
 		<Entity uid="2584">
 			<Template>gaia/fish/generic</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="313.3014" z="436.03562"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="47242"/>
 		</Entity>
 		<Entity uid="2585">
 			<Template>gaia/fish/generic</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="275.34693" z="444.84083"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="28740"/>
 		</Entity>
 		<Entity uid="2586">
 			<Template>gaia/fish/generic</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="142.5955" z="687.69581"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="62138"/>
 		</Entity>
 		<Entity uid="2587">
 			<Template>gaia/fish/generic</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="160.31791" z="730.79871"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="30290"/>
 		</Entity>
 		<Entity uid="2588">
 			<Template>gaia/fish/generic</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="181.96128" z="730.7345"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="13040"/>
 		</Entity>
 		<Entity uid="2589">
 			<Template>gaia/fish/generic</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="158.2953" z="708.8689"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="28106"/>
 		</Entity>
 		<Entity uid="2590">
 			<Template>gaia/fish/generic</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="283.21067" z="918.64344"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="5764"/>
 		</Entity>
 		<Entity uid="2591">
 			<Template>gaia/fish/generic</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="323.10767" z="975.60639"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="36448"/>
 		</Entity>
 		<Entity uid="2592">
 			<Template>gaia/fish/generic</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="321.71152" z="939.94556"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="55042"/>
 		</Entity>
 		<Entity uid="2593">
 			<Template>gaia/fish/generic</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="285.4806" z="947.30726"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="22878"/>
 		</Entity>
 		<Entity uid="2594">
 			<Template>gaia/fish/generic</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="279.54068" z="969.65436"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="63210"/>
 		</Entity>
 		<Entity uid="2595">
 			<Template>gaia/fish/generic</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="389.36509" z="1278.79053"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="33852"/>
 		</Entity>
 		<Entity uid="2596">
 			<Template>gaia/fish/generic</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="345.41953" z="1313.59791"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="44744"/>
 		</Entity>
 		<Entity uid="2597">
 			<Template>gaia/fish/generic</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="744.85877" z="1565.25196"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="10888"/>
 		</Entity>
 		<Entity uid="2598">
 			<Template>gaia/fish/generic</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="809.84662" z="1510.47876"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="60542"/>
 		</Entity>
 		<Entity uid="2599">
 			<Template>gaia/fish/generic</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="814.96808" z="1510.9242"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="4308"/>
 		</Entity>
 		<Entity uid="2600">
 			<Template>gaia/fish/generic</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="1219.49659" z="1580.70264"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="51090"/>
 		</Entity>
 		<Entity uid="2601">
 			<Template>gaia/fish/generic</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="1236.8501" z="1505.29883"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="37106"/>
 		</Entity>
 		<Entity uid="2602">
 			<Template>gaia/fish/generic</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="1226.21888" z="1461.31348"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="57690"/>
 		</Entity>
 		<Entity uid="2603">
 			<Template>gaia/fish/generic</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="956.57477" z="1591.9275"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="2672"/>
 		</Entity>
 		<Entity uid="2604">
 			<Template>gaia/fish/generic</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="926.89466" z="1671.60987"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="24742"/>
@@ -20735,14 +20735,14 @@
 		</Entity>
 		<Entity uid="3544">
 			<Template>gaia/treasure/food_barrel</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="947.19355" z="698.79957"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="50626"/>
 		</Entity>
 		<Entity uid="3545">
 			<Template>gaia/treasure/metal</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="949.21711" z="700.90992"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="62788"/>
@@ -21281,14 +21281,14 @@
 		</Entity>
 		<Entity uid="3737">
 			<Template>gaia/treasure/stone</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="952.4969" z="697.15992"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="21784"/>
 		</Entity>
 		<Entity uid="3738">
 			<Template>gaia/treasure/wood</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="947.42646" z="692.4173"/>
 			<Orientation y="-0.16993"/>
 			<Actor seed="38034"/>

--- a/maps/scenarios/caledonia_2p.xml
+++ b/maps/scenarios/caledonia_2p.xml
@@ -1348,14 +1348,14 @@
 		</Entity>
 		<Entity uid="226">
 			<Template>gaia/fruit/berry_03</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="2887.61866" z="801.12836"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="4993"/>
 		</Entity>
 		<Entity uid="227">
 			<Template>gaia/fruit/berry_03</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="2898.2732" z="801.79712"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="51640"/>
@@ -3084,14 +3084,14 @@
 		</Entity>
 		<Entity uid="475">
 			<Template>rubble/rubble_stone_5x5</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="1885.67676" z="2310.521"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="719"/>
 		</Entity>
 		<Entity uid="476">
 			<Template>rubble/rubble_stone_5x5</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="2335.99585" z="2715.00391"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="6032"/>
@@ -3511,7 +3511,7 @@
 		</Entity>
 		<Entity uid="538">
 			<Template>gaia/fish/tilapia</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="3034.43775" z="1406.98182"/>
 			<Orientation y="1.97963"/>
 			<Actor seed="32631"/>
@@ -3672,21 +3672,21 @@
 		</Entity>
 		<Entity uid="561">
 			<Template>gaia/fish/generic</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="1765.8943" z="1249.29444"/>
 			<Orientation y="2.48717"/>
 			<Actor seed="32064"/>
 		</Entity>
 		<Entity uid="562">
 			<Template>gaia/fish/generic</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="1574.75501" z="1209.6233"/>
 			<Orientation y="2.61773"/>
 			<Actor seed="50991"/>
 		</Entity>
 		<Entity uid="563">
 			<Template>gaia/fish/generic</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="1657.83277" z="1492.08423"/>
 			<Orientation y="-0.13852"/>
 			<Actor seed="58849"/>
@@ -3721,7 +3721,7 @@
 		</Entity>
 		<Entity uid="568">
 			<Template>gaia/fish/generic</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="1300.65992" z="925.98871"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="26553"/>
@@ -3735,7 +3735,7 @@
 		</Entity>
 		<Entity uid="570">
 			<Template>gaia/fish/generic</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="190.46546" z="1825.91041"/>
 			<Orientation y="0.86802"/>
 			<Actor seed="25935"/>
@@ -3791,14 +3791,14 @@
 		</Entity>
 		<Entity uid="578">
 			<Template>gaia/fish/generic</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="1733.5127" z="1996.20337"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="42909"/>
 		</Entity>
 		<Entity uid="579">
 			<Template>gaia/fish/generic</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="1612.56702" z="1649.20484"/>
 			<Orientation y="2.09871"/>
 			<Actor seed="21816"/>
@@ -3819,7 +3819,7 @@
 		</Entity>
 		<Entity uid="582">
 			<Template>gaia/fish/tuna</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="1636.40296" z="1356.46338"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="38364"/>
@@ -3854,21 +3854,21 @@
 		</Entity>
 		<Entity uid="587">
 			<Template>gaia/fish/tuna</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="416.04883" z="2079.75831"/>
 			<Orientation y="2.34273"/>
 			<Actor seed="7038"/>
 		</Entity>
 		<Entity uid="588">
 			<Template>gaia/fish/tuna</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="1793.01172" z="1128.41749"/>
 			<Orientation y="1.78556"/>
 			<Actor seed="1217"/>
 		</Entity>
 		<Entity uid="589">
 			<Template>gaia/fish/tuna</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="1640.66211" z="244.82609"/>
 			<Orientation y="1.79217"/>
 			<Actor seed="33894"/>
@@ -4274,7 +4274,7 @@
 		</Entity>
 		<Entity uid="647">
 			<Template>gaia/fauna_whale_humpback</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="1688.97205" z="1522.85645"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="24436"/>
@@ -6180,7 +6180,7 @@
 		</Entity>
 		<Entity uid="949">
 			<Template>gaia/tree/pine_black</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="2415.1067" z="2235.2085"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="10617"/>
@@ -6509,7 +6509,7 @@
 		</Entity>
 		<Entity uid="996">
 			<Template>gaia/tree/pine_black</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="2605.89234" z="2013.74476"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="30089"/>
@@ -8070,14 +8070,14 @@
 		</Entity>
 		<Entity uid="1220">
 			<Template>gaia/tree/temperate</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="2696.46412" z="1100.27942"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="62417"/>
 		</Entity>
 		<Entity uid="1221">
 			<Template>gaia/tree/temperate</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="2675.02417" z="1101.80787"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="27636"/>
@@ -8112,7 +8112,7 @@
 		</Entity>
 		<Entity uid="1226">
 			<Template>gaia/tree/temperate</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="2669.73902" z="1090.5027"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="37221"/>
@@ -9155,7 +9155,7 @@
 		</Entity>
 		<Entity uid="1375">
 			<Template>gaia/tree/temperate</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="2456.40137" z="955.87879"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="53635"/>
@@ -9897,7 +9897,7 @@
 		</Entity>
 		<Entity uid="1481">
 			<Template>gaia/tree/poplar_lombardy_autumn</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="2881.6443" z="1649.34205"/>
 			<Orientation y="1.57081"/>
 			<Actor seed="25904"/>
@@ -12494,7 +12494,7 @@
 		</Entity>
 		<Entity uid="1853">
 			<Template>gaia/tree/euro_birch</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="2081.06568" z="2361.43506"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="37062"/>
@@ -31144,7 +31144,7 @@
 		</Entity>
 		<Entity uid="4989">
 			<Template>gaia/fish/tuna</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="2017.74061" z="3631.84571"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="60103"/>

--- a/maps/scenarios/cyzicus.xml
+++ b/maps/scenarios/cyzicus.xml
@@ -2580,14 +2580,14 @@
 		</Entity>
 		<Entity uid="424">
 			<Template>gaia/tree/cypress</Template>
-			<Player>3</Player>
+			<Player>0</Player>
 			<Position x="694.67792" z="1336.16736"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="28026"/>
 		</Entity>
 		<Entity uid="425">
 			<Template>gaia/tree/cypress</Template>
-			<Player>3</Player>
+			<Player>0</Player>
 			<Position x="714.95875" z="1331.2865"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="55597"/>
@@ -3931,28 +3931,28 @@
 		</Entity>
 		<Entity uid="627">
 			<Template>gaia/fauna_horse</Template>
-			<Player>3</Player>
+			<Player>0</Player>
 			<Position x="582.10265" z="934.72951"/>
 			<Orientation y="-0.64586"/>
 			<Actor seed="44711"/>
 		</Entity>
 		<Entity uid="628">
 			<Template>gaia/fauna_horse</Template>
-			<Player>3</Player>
+			<Player>0</Player>
 			<Position x="590.91431" z="940.17725"/>
 			<Orientation y="-0.73873"/>
 			<Actor seed="767"/>
 		</Entity>
 		<Entity uid="629">
 			<Template>gaia/fauna_horse</Template>
-			<Player>3</Player>
+			<Player>0</Player>
 			<Position x="585.79386" z="936.42472"/>
 			<Orientation y="-2.8301"/>
 			<Actor seed="19866"/>
 		</Entity>
 		<Entity uid="630">
 			<Template>gaia/fauna_horse</Template>
-			<Player>3</Player>
+			<Player>0</Player>
 			<Position x="577.29702" z="941.37829"/>
 			<Orientation y="-1.36915"/>
 			<Actor seed="11864"/>
@@ -6283,7 +6283,7 @@
 		</Entity>
 		<Entity uid="1032">
 			<Template>gaia/treasure/food_bin</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="622.05268" z="156.8744"/>
 			<Orientation y="-3.0891"/>
 			<Actor seed="22283"/>
@@ -9521,7 +9521,7 @@
 		</Entity>
 		<Entity uid="1569">
 			<Template>gaia/tree/tamarix</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="373.65696" z="1383.73267"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="39878"/>
@@ -10236,28 +10236,28 @@
 		</Entity>
 		<Entity uid="1682">
 			<Template>gaia/fauna_horse</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="603.88416" z="80.92573"/>
 			<Orientation y="5.57088"/>
 			<Actor seed="59343"/>
 		</Entity>
 		<Entity uid="1683">
 			<Template>gaia/fauna_horse</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="592.98743" z="105.17595"/>
 			<Orientation y="3.21775"/>
 			<Actor seed="35258"/>
 		</Entity>
 		<Entity uid="1684">
 			<Template>gaia/fauna_horse</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="608.102" z="95.83275"/>
 			<Orientation y="0.75017"/>
 			<Actor seed="33434"/>
 		</Entity>
 		<Entity uid="1685">
 			<Template>gaia/fauna_horse</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="592.71296" z="96.76586"/>
 			<Orientation y="7.82338"/>
 			<Actor seed="63781"/>
@@ -11163,49 +11163,49 @@
 		</Entity>
 		<Entity uid="1913">
 			<Template>gaia/fauna_chicken</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="298.02494" z="1290.1969"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="62731"/>
 		</Entity>
 		<Entity uid="1914">
 			<Template>gaia/fauna_chicken</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="269.36313" z="1270.85901"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="46750"/>
 		</Entity>
 		<Entity uid="1915">
 			<Template>gaia/fauna_chicken</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="261.44169" z="1281.90015"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="28645"/>
 		</Entity>
 		<Entity uid="1916">
 			<Template>gaia/fauna_chicken</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="260.6554" z="1266.85633"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="7571"/>
 		</Entity>
 		<Entity uid="1917">
 			<Template>gaia/fauna_chicken</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="311.9705" z="1284.948"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="48727"/>
 		</Entity>
 		<Entity uid="1918">
 			<Template>gaia/fauna_chicken</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="299.91514" z="1271.55982"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="45117"/>
 		</Entity>
 		<Entity uid="1919">
 			<Template>gaia/fauna_chicken</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="244.74189" z="1295.28663"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="56207"/>
@@ -11218,21 +11218,21 @@
 		</Entity>
 		<Entity uid="1923">
 			<Template>gaia/fauna_rabbit</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="414.84809" z="1303.94251"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="62227"/>
 		</Entity>
 		<Entity uid="1924">
 			<Template>gaia/fauna_rabbit</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="465.15998" z="1241.09864"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="14982"/>
 		</Entity>
 		<Entity uid="1925">
 			<Template>gaia/fauna_rabbit</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="550.1778" z="1287.23755"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="49630"/>
@@ -11246,14 +11246,14 @@
 		</Entity>
 		<Entity uid="1927">
 			<Template>gaia/tree/dead</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="318.01652" z="1281.90284"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="50090"/>
 		</Entity>
 		<Entity uid="1928">
 			<Template>gaia/tree/dead</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="247.40879" z="1315.96497"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="61109"/>
@@ -11421,126 +11421,126 @@
 		</Entity>
 		<Entity uid="1957">
 			<Template>gaia/tree/oak_large</Template>
-			<Player>3</Player>
+			<Player>0</Player>
 			<Position x="755.97327" z="1021.94886"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="17727"/>
 		</Entity>
 		<Entity uid="1958">
 			<Template>gaia/tree/oak_large</Template>
-			<Player>3</Player>
+			<Player>0</Player>
 			<Position x="762.29737" z="990.2942"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="45400"/>
 		</Entity>
 		<Entity uid="1959">
 			<Template>gaia/tree/oak_large</Template>
-			<Player>3</Player>
+			<Player>0</Player>
 			<Position x="708.12226" z="980.17438"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="20825"/>
 		</Entity>
 		<Entity uid="1960">
 			<Template>gaia/tree/oak_large</Template>
-			<Player>3</Player>
+			<Player>0</Player>
 			<Position x="752.48719" z="949.88141"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="53329"/>
 		</Entity>
 		<Entity uid="1961">
 			<Template>gaia/tree/oak_large</Template>
-			<Player>3</Player>
+			<Player>0</Player>
 			<Position x="769.03205" z="911.29877"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="17873"/>
 		</Entity>
 		<Entity uid="1962">
 			<Template>gaia/tree/oak_large</Template>
-			<Player>3</Player>
+			<Player>0</Player>
 			<Position x="707.75306" z="907.05182"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="35133"/>
 		</Entity>
 		<Entity uid="1963">
 			<Template>gaia/tree/oak_large</Template>
-			<Player>3</Player>
+			<Player>0</Player>
 			<Position x="690.82972" z="933.44538"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="64890"/>
 		</Entity>
 		<Entity uid="1964">
 			<Template>gaia/tree/oak_large</Template>
-			<Player>3</Player>
+			<Player>0</Player>
 			<Position x="646.5204" z="897.59504"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="29703"/>
 		</Entity>
 		<Entity uid="1965">
 			<Template>gaia/tree/oak_large</Template>
-			<Player>3</Player>
+			<Player>0</Player>
 			<Position x="633.40485" z="849.41651"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="26203"/>
 		</Entity>
 		<Entity uid="1966">
 			<Template>gaia/tree/oak_new</Template>
-			<Player>3</Player>
+			<Player>0</Player>
 			<Position x="732.2353" z="929.38715"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="47019"/>
 		</Entity>
 		<Entity uid="1967">
 			<Template>gaia/tree/oak_new</Template>
-			<Player>3</Player>
+			<Player>0</Player>
 			<Position x="780.31788" z="953.4516"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="54792"/>
 		</Entity>
 		<Entity uid="1968">
 			<Template>gaia/tree/oak_new</Template>
-			<Player>3</Player>
+			<Player>0</Player>
 			<Position x="732.68873" z="995.70331"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="34029"/>
 		</Entity>
 		<Entity uid="1969">
 			<Template>gaia/tree/oak_new</Template>
-			<Player>3</Player>
+			<Player>0</Player>
 			<Position x="669.3581" z="881.39191"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="53035"/>
 		</Entity>
 		<Entity uid="1970">
 			<Template>gaia/tree/oak</Template>
-			<Player>3</Player>
+			<Player>0</Player>
 			<Position x="734.69855" z="968.0821"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="8043"/>
 		</Entity>
 		<Entity uid="1971">
 			<Template>gaia/tree/oak</Template>
-			<Player>3</Player>
+			<Player>0</Player>
 			<Position x="695.9615" z="956.66211"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="41026"/>
 		</Entity>
 		<Entity uid="1972">
 			<Template>gaia/tree/oak</Template>
-			<Player>3</Player>
+			<Player>0</Player>
 			<Position x="741.94495" z="897.42414"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="65133"/>
 		</Entity>
 		<Entity uid="1973">
 			<Template>gaia/tree/oak</Template>
-			<Player>3</Player>
+			<Player>0</Player>
 			<Position x="663.31391" z="917.99512"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="12504"/>
 		</Entity>
 		<Entity uid="1974">
 			<Template>gaia/tree/oak</Template>
-			<Player>3</Player>
+			<Player>0</Player>
 			<Position x="764.34534" z="1046.62708"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="58682"/>

--- a/maps/scenarios/first_battle_of_numantia.xml
+++ b/maps/scenarios/first_battle_of_numantia.xml
@@ -518,7 +518,7 @@
 		</Entity>
 		<Entity uid="256">
 			<Template>gaia/fauna_rabbit</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="492.11548" z="911.70337"/>
 			<Orientation y="4.97904"/>
 			<Actor seed="56821"/>
@@ -1717,91 +1717,91 @@
 		</Entity>
 		<Entity uid="524">
 			<Template>gaia/fauna_chicken</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="565.00178" z="671.73548"/>
 			<Orientation y="-0.83997"/>
 			<Actor seed="58782"/>
 		</Entity>
 		<Entity uid="525">
 			<Template>gaia/fauna_chicken</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="558.43158" z="680.29426"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="14964"/>
 		</Entity>
 		<Entity uid="526">
 			<Template>gaia/fauna_chicken</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="562.23243" z="678.37897"/>
 			<Orientation y="0.74363"/>
 			<Actor seed="1756"/>
 		</Entity>
 		<Entity uid="528">
 			<Template>gaia/fauna_chicken</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="560.3783" z="685.49885"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="54776"/>
 		</Entity>
 		<Entity uid="529">
 			<Template>gaia/fauna_chicken</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="555.97681" z="686.29053"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="54382"/>
 		</Entity>
 		<Entity uid="530">
 			<Template>gaia/fauna_chicken</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="555.06373" z="684.14954"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="35434"/>
 		</Entity>
 		<Entity uid="531">
 			<Template>gaia/fauna_chicken</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="553.38483" z="682.62092"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="30264"/>
 		</Entity>
 		<Entity uid="532">
 			<Template>gaia/fauna_chicken</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="550.56202" z="684.21851"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="41958"/>
 		</Entity>
 		<Entity uid="533">
 			<Template>gaia/fauna_chicken</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="561.9997" z="669.1515"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="30836"/>
 		</Entity>
 		<Entity uid="534">
 			<Template>gaia/fauna_chicken</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="564.3296" z="666.20954"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="53080"/>
 		</Entity>
 		<Entity uid="535">
 			<Template>gaia/fauna_chicken</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="564.18049" z="662.59247"/>
 			<Orientation y="0.00205"/>
 			<Actor seed="1258"/>
 		</Entity>
 		<Entity uid="536">
 			<Template>gaia/fauna_chicken</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="564.33716" z="678.90998"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="3552"/>
 		</Entity>
 		<Entity uid="537">
 			<Template>gaia/fauna_chicken</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="567.4787" z="680.89496"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="27854"/>
@@ -1864,70 +1864,70 @@
 		</Entity>
 		<Entity uid="548">
 			<Template>gaia/fruit/apple</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="536.79261" z="688.30658"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="8348"/>
 		</Entity>
 		<Entity uid="549">
 			<Template>gaia/fruit/apple</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="530.23914" z="690.5323"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="48398"/>
 		</Entity>
 		<Entity uid="550">
 			<Template>gaia/fruit/apple</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="619.59803" z="710.90546"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="20028"/>
 		</Entity>
 		<Entity uid="553">
 			<Template>gaia/fruit/apple</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="632.00239" z="709.6023"/>
 			<Orientation y="-2.45307"/>
 			<Actor seed="49248"/>
 		</Entity>
 		<Entity uid="554">
 			<Template>gaia/fruit/apple</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="627.28418" z="582.3"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="11012"/>
 		</Entity>
 		<Entity uid="555">
 			<Template>gaia/fruit/apple</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="571.66297" z="81.85932"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="61388"/>
 		</Entity>
 		<Entity uid="556">
 			<Template>gaia/fruit/apple</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="570.98469" z="52.07374"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="50336"/>
 		</Entity>
 		<Entity uid="557">
 			<Template>gaia/fruit/apple</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="637.57874" z="111.1613"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="3846"/>
 		</Entity>
 		<Entity uid="558">
 			<Template>gaia/fruit/apple</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="188.58017" z="210.83811"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="48646"/>
 		</Entity>
 		<Entity uid="559">
 			<Template>gaia/fruit/apple</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="241.51325" z="210.64844"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="52180"/>
@@ -1983,35 +1983,35 @@
 		</Entity>
 		<Entity uid="582">
 			<Template>gaia/fauna_horse</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="593.8329" z="590.94837"/>
 			<Orientation y="2.94587"/>
 			<Actor seed="63204"/>
 		</Entity>
 		<Entity uid="583">
 			<Template>gaia/fauna_horse</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="591.52894" z="590.58417"/>
 			<Orientation y="2.9488"/>
 			<Actor seed="47926"/>
 		</Entity>
 		<Entity uid="585">
 			<Template>gaia/fauna_horse</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="588.82679" z="590.62818"/>
 			<Orientation y="2.84406"/>
 			<Actor seed="31208"/>
 		</Entity>
 		<Entity uid="587">
 			<Template>gaia/fauna_horse</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="586.22132" z="589.88727"/>
 			<Orientation y="2.91895"/>
 			<Actor seed="42806"/>
 		</Entity>
 		<Entity uid="589">
 			<Template>gaia/fauna_horse</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="583.79444" z="589.52381"/>
 			<Orientation y="3.0624"/>
 			<Actor seed="6874"/>
@@ -12661,7 +12661,7 @@
 		</Entity>
 		<Entity uid="2512">
 			<Template>gaia/fauna_chicken</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="917.4137" z="648.5998"/>
 			<Orientation y="1.49791"/>
 			<Actor seed="55950"/>
@@ -13228,28 +13228,28 @@
 		</Entity>
 		<Entity uid="2736">
 			<Template>gaia/treasure/food_barrel</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="674.15485" z="252.8307"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="8586"/>
 		</Entity>
 		<Entity uid="2737">
 			<Template>gaia/treasure/food_bin</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="677.15357" z="251.05347"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="41284"/>
 		</Entity>
 		<Entity uid="2738">
 			<Template>gaia/treasure/food_crate</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="674.84827" z="249.50892"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="11526"/>
 		</Entity>
 		<Entity uid="2739">
 			<Template>gaia/treasure/wood</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="669.25489" z="243.46875"/>
 			<Orientation y="0.46676"/>
 			<Actor seed="18458"/>

--- a/maps/scenarios/linne_foirthe_8p.xml
+++ b/maps/scenarios/linne_foirthe_8p.xml
@@ -94983,70 +94983,70 @@
 		</Entity>
 		<Entity uid="14374">
 			<Template>gaia/fruit/grapes</Template>
-			<Player>6</Player>
+			<Player>0</Player>
 			<Position x="1383.86512" z="156.9087"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="44838"/>
 		</Entity>
 		<Entity uid="14375">
 			<Template>gaia/fruit/grapes</Template>
-			<Player>6</Player>
+			<Player>0</Player>
 			<Position x="1378.20716" z="153.0832"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="49480"/>
 		</Entity>
 		<Entity uid="14376">
 			<Template>gaia/fruit/grapes</Template>
-			<Player>6</Player>
+			<Player>0</Player>
 			<Position x="1371.93226" z="149.04966"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="1286"/>
 		</Entity>
 		<Entity uid="14377">
 			<Template>gaia/fruit/grapes</Template>
-			<Player>6</Player>
+			<Player>0</Player>
 			<Position x="1365.08228" z="144.48295"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="50114"/>
 		</Entity>
 		<Entity uid="14378">
 			<Template>gaia/fruit/grapes</Template>
-			<Player>6</Player>
+			<Player>0</Player>
 			<Position x="1375.9452" z="164.046"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="32904"/>
 		</Entity>
 		<Entity uid="14379">
 			<Template>gaia/fruit/grapes</Template>
-			<Player>6</Player>
+			<Player>0</Player>
 			<Position x="1370.62281" z="159.70496"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="6834"/>
 		</Entity>
 		<Entity uid="14380">
 			<Template>gaia/fruit/grapes</Template>
-			<Player>6</Player>
+			<Player>0</Player>
 			<Position x="1365.02576" z="156.61692"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="10404"/>
 		</Entity>
 		<Entity uid="14381">
 			<Template>gaia/fruit/grapes</Template>
-			<Player>6</Player>
+			<Player>0</Player>
 			<Position x="1358.6753" z="152.55631"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="65495"/>
 		</Entity>
 		<Entity uid="14382">
 			<Template>gaia/ore/tropical_large</Template>
-			<Player>6</Player>
+			<Player>0</Player>
 			<Position x="892.13312" z="788.91321"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="33912"/>
 		</Entity>
 		<Entity uid="14383">
 			<Template>gaia/ore/tropical_large</Template>
-			<Player>6</Player>
+			<Player>0</Player>
 			<Position x="1293.24878" z="770.02802"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="46946"/>

--- a/maps/scenarios/masada_2p.xml
+++ b/maps/scenarios/masada_2p.xml
@@ -359,7 +359,7 @@
 		</Entity>
 		<Entity uid="131">
 			<Template>gaia/ore/savanna_large</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="985.39997" z="679.39594"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="22881"/>
@@ -380,14 +380,14 @@
 		</Entity>
 		<Entity uid="136">
 			<Template>gaia/treasure/stone_pile_sandstone</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="1109.4159" z="811.04456"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="16979"/>
 		</Entity>
 		<Entity uid="137">
 			<Template>gaia/treasure/stone</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="947.81336" z="774.21381"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="31109"/>
@@ -1206,35 +1206,35 @@
 		</Entity>
 		<Entity uid="681">
 			<Template>gaia/treasure/food_crate</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="349.80738" z="580.63971"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="56951"/>
 		</Entity>
 		<Entity uid="682">
 			<Template>gaia/treasure/food_crate</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="638.49885" z="649.71161"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="63337"/>
 		</Entity>
 		<Entity uid="683">
 			<Template>gaia/treasure/food_crate</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="699.33326" z="839.24463"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="47903"/>
 		</Entity>
 		<Entity uid="684">
 			<Template>gaia/treasure/food_crate</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="640.4137" z="831.46985"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="6333"/>
 		</Entity>
 		<Entity uid="685">
 			<Template>gaia/treasure/food_crate</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="659.66773" z="1005.2165"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="42904"/>
@@ -1290,7 +1290,7 @@
 		</Entity>
 		<Entity uid="693">
 			<Template>gaia/treasure/food_jars</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="1151.61231" z="384.4795"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="33574"/>
@@ -1304,7 +1304,7 @@
 		</Entity>
 		<Entity uid="695">
 			<Template>gaia/treasure/food_jars</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="1265.06177" z="195.21906"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="35640"/>
@@ -1430,7 +1430,7 @@
 		</Entity>
 		<Entity uid="713">
 			<Template>gaia/treasure/metal</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="909.54432" z="1112.8888"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="39220"/>
@@ -1486,14 +1486,14 @@
 		</Entity>
 		<Entity uid="721">
 			<Template>gaia/treasure/metal</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="1309.09473" z="273.43525"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="5414"/>
 		</Entity>
 		<Entity uid="722">
 			<Template>gaia/treasure/metal</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="995.9419" z="167.80488"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="48337"/>
@@ -1528,14 +1528,14 @@
 		</Entity>
 		<Entity uid="727">
 			<Template>gaia/treasure/stone_pile_sandstone</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="572.0835" z="786.30103"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="8187"/>
 		</Entity>
 		<Entity uid="728">
 			<Template>gaia/treasure/stone_pile_sandstone</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="352.1898" z="1136.12354"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="45166"/>
@@ -1563,7 +1563,7 @@
 		</Entity>
 		<Entity uid="732">
 			<Template>gaia/treasure/stone_pile_sandstone</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="1308.62452" z="1286.28956"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="19126"/>
@@ -1584,14 +1584,14 @@
 		</Entity>
 		<Entity uid="735">
 			<Template>gaia/treasure/wood_lumber</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="1770.25" z="1370.24646"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="43179"/>
 		</Entity>
 		<Entity uid="736">
 			<Template>gaia/treasure/wood_lumber</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="1406.98243" z="992.68781"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="9824"/>
@@ -1626,14 +1626,14 @@
 		</Entity>
 		<Entity uid="741">
 			<Template>gaia/treasure/wood_lumber</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="403.67035" z="514.90052"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="21639"/>
 		</Entity>
 		<Entity uid="742">
 			<Template>gaia/treasure/wood_lumber</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="839.06165" z="415.56482"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="24176"/>
@@ -2725,7 +2725,7 @@
 		</Entity>
 		<Entity uid="899">
 			<Template>gaia/ore/desert_large</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="793.31373" z="1597.50806"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="23238"/>
@@ -3649,91 +3649,91 @@
 		</Entity>
 		<Entity uid="1036">
 			<Template>rubble/rubble_field</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="1371.39441" z="1121.54273"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="5031"/>
 		</Entity>
 		<Entity uid="1037">
 			<Template>rubble/rubble_field</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="1405.47156" z="1147.65064"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="60198"/>
 		</Entity>
 		<Entity uid="1038">
 			<Template>rubble/rubble_field</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="1395.63917" z="1097.61268"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="55060"/>
 		</Entity>
 		<Entity uid="1039">
 			<Template>rubble/rubble_field</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="1421.74366" z="1119.49402"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="38460"/>
 		</Entity>
 		<Entity uid="1040">
 			<Template>rubble/rubble_field</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="1778.80152" z="941.72626"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="16522"/>
 		</Entity>
 		<Entity uid="1041">
 			<Template>rubble/rubble_field</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="1752.9319" z="966.97034"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="50341"/>
 		</Entity>
 		<Entity uid="1042">
 			<Template>rubble/rubble_field</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="1730.57667" z="577.36622"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="21797"/>
 		</Entity>
 		<Entity uid="1043">
 			<Template>rubble/rubble_stone_2x2</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="1300.37415" z="571.29365"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="32830"/>
 		</Entity>
 		<Entity uid="1044">
 			<Template>rubble/rubble_stone_2x2</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="1245.5011" z="1334.37208"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="22236"/>
 		</Entity>
 		<Entity uid="1045">
 			<Template>rubble/rubble_stone_4x2</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="1490.64783" z="1375.49195"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="24117"/>
 		</Entity>
 		<Entity uid="1046">
 			<Template>rubble/rubble_stone_4x2</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="1836.81324" z="450.05372"/>
 			<Orientation y="-0.11164"/>
 			<Actor seed="28148"/>
 		</Entity>
 		<Entity uid="1047">
 			<Template>rubble/rubble_wood_3x3</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="1628.2074" z="403.95984"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="26263"/>
 		</Entity>
 		<Entity uid="1048">
 			<Template>rubble/rubble_rome_sb</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="1748.92725" z="732.45258"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="52847"/>

--- a/maps/scenarios/olimpus_4.xml
+++ b/maps/scenarios/olimpus_4.xml
@@ -33080,19 +33080,19 @@
 		</Entity>
 		<Entity uid="6298">
 			<Template>gaia/tree/carob</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="310" z="1286"/>
 			<Orientation y="2.1448"/>
 		</Entity>
 		<Entity uid="6299">
 			<Template>gaia/tree/carob</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="362" z="1278"/>
 			<Orientation y="4.1776"/>
 		</Entity>
 		<Entity uid="6300">
 			<Template>gaia/tree/carob</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="370" z="1282"/>
 			<Orientation y="4.23981"/>
 		</Entity>
@@ -33134,7 +33134,7 @@
 		</Entity>
 		<Entity uid="6307">
 			<Template>gaia/tree/cretan_date_palm_short</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="362" z="1298"/>
 			<Orientation y="1.84966"/>
 		</Entity>
@@ -33146,7 +33146,7 @@
 		</Entity>
 		<Entity uid="6309">
 			<Template>gaia/tree/carob</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="374" z="1294"/>
 			<Orientation y="5.7395"/>
 		</Entity>
@@ -33194,19 +33194,19 @@
 		</Entity>
 		<Entity uid="6317">
 			<Template>gaia/tree/cretan_date_palm_tall</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="314" z="1282"/>
 			<Orientation y="1.43212"/>
 		</Entity>
 		<Entity uid="6318">
 			<Template>gaia/tree/cretan_date_palm_short</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="358" z="1278"/>
 			<Orientation y="0.31293"/>
 		</Entity>
 		<Entity uid="6319">
 			<Template>gaia/tree/cretan_date_palm_tall</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="358" z="1282"/>
 			<Orientation y="0.9187"/>
 		</Entity>
@@ -33224,19 +33224,19 @@
 		</Entity>
 		<Entity uid="6322">
 			<Template>gaia/tree/carob</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="346" z="1298"/>
 			<Orientation y="5.75715"/>
 		</Entity>
 		<Entity uid="6323">
 			<Template>gaia/tree/carob</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="362" z="1294"/>
 			<Orientation y="5.44301"/>
 		</Entity>
 		<Entity uid="6324">
 			<Template>gaia/tree/cretan_date_palm_tall</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="366" z="1290"/>
 			<Orientation y="6.06205"/>
 		</Entity>
@@ -33290,37 +33290,37 @@
 		</Entity>
 		<Entity uid="6333">
 			<Template>gaia/tree/cretan_date_palm_short</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="322" z="1278"/>
 			<Orientation y="1.46822"/>
 		</Entity>
 		<Entity uid="6334">
 			<Template>gaia/tree/cretan_date_palm_short</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="322" z="1294"/>
 			<Orientation y="1.93928"/>
 		</Entity>
 		<Entity uid="6335">
 			<Template>gaia/tree/cretan_date_palm_short</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="342" z="1294"/>
 			<Orientation y="5.8906"/>
 		</Entity>
 		<Entity uid="6336">
 			<Template>gaia/tree/cretan_date_palm_tall</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="354" z="1294"/>
 			<Orientation y="5.94561"/>
 		</Entity>
 		<Entity uid="6337">
 			<Template>gaia/tree/cretan_date_palm_tall</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="354" z="1290"/>
 			<Orientation y="5.97687"/>
 		</Entity>
 		<Entity uid="6338">
 			<Template>gaia/tree/cretan_date_palm_tall</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="326" z="1294"/>
 			<Orientation y="2.70054"/>
 		</Entity>
@@ -33350,19 +33350,19 @@
 		</Entity>
 		<Entity uid="6343">
 			<Template>gaia/tree/cretan_date_palm_tall</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="326" z="1278"/>
 			<Orientation y="5.94484"/>
 		</Entity>
 		<Entity uid="6344">
 			<Template>gaia/tree/carob</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="346" z="1282"/>
 			<Orientation y="4.34758"/>
 		</Entity>
 		<Entity uid="6345">
 			<Template>gaia/tree/cretan_date_palm_short</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="330" z="1290"/>
 			<Orientation y="0.33907"/>
 		</Entity>
@@ -33392,13 +33392,13 @@
 		</Entity>
 		<Entity uid="6350">
 			<Template>gaia/tree/cretan_date_palm_short</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="334" z="1286"/>
 			<Orientation y="5.51177"/>
 		</Entity>
 		<Entity uid="6351">
 			<Template>gaia/tree/cretan_date_palm_short</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="334" z="1282"/>
 			<Orientation y="0.76735"/>
 		</Entity>
@@ -43206,7 +43206,7 @@
 		</Entity>
 		<Entity uid="8306">
 			<Template>gaia/tree/cretan_date_palm_short</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="369.07398" z="1276.99013"/>
 			<Orientation y="-0.06534"/>
 		</Entity>
@@ -44640,7 +44640,7 @@
 		</Entity>
 		<Entity uid="8583">
 			<Template>gaia/tree/poplar_lombardy</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="389.60233" z="1283.7661"/>
 			<Orientation y="0.4071"/>
 		</Entity>
@@ -44694,7 +44694,7 @@
 		</Entity>
 		<Entity uid="8593">
 			<Template>gaia/tree/poplar_lombardy</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="525.5405" z="1287.31748"/>
 			<Orientation y="-3.532"/>
 		</Entity>
@@ -50693,686 +50693,686 @@
 		</Entity>
 		<Entity uid="9786">
 			<Template>gaia/tree/cypress</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="271.0087" z="1283.04297"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="46617"/>
 		</Entity>
 		<Entity uid="9787">
 			<Template>gaia/tree/cypress</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="263.40284" z="1276.88355"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="21158"/>
 		</Entity>
 		<Entity uid="9788">
 			<Template>gaia/tree/cypress</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="252.19114" z="1262.57935"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="22646"/>
 		</Entity>
 		<Entity uid="9789">
 			<Template>gaia/tree/cypress</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="235.97977" z="1264.54847"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="61877"/>
 		</Entity>
 		<Entity uid="9790">
 			<Template>gaia/tree/cypress</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="227.91895" z="1275.14356"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="7365"/>
 		</Entity>
 		<Entity uid="9791">
 			<Template>gaia/tree/cypress</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="219.5445" z="1284.80958"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="2626"/>
 		</Entity>
 		<Entity uid="9792">
 			<Template>gaia/tree/cypress</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="251.74253" z="1306.76124"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="24369"/>
 		</Entity>
 		<Entity uid="9793">
 			<Template>gaia/tree/cypress</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="246.4932" z="1313.63416"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="19452"/>
 		</Entity>
 		<Entity uid="9794">
 			<Template>gaia/tree/date_palm</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="255.02631" z="1301.54627"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="20280"/>
 		</Entity>
 		<Entity uid="9795">
 			<Template>gaia/tree/date_palm</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="256.30365" z="1271.40638"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="15495"/>
 		</Entity>
 		<Entity uid="9797">
 			<Template>gaia/tree/bush_temperate</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="257.74341" z="1298.98011"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="6336"/>
 		</Entity>
 		<Entity uid="9798">
 			<Template>gaia/tree/bush_temperate</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="261.04343" z="1295.34815"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="35584"/>
 		</Entity>
 		<Entity uid="9799">
 			<Template>gaia/tree/bush_temperate</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="266.22706" z="1290.19068"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="7043"/>
 		</Entity>
 		<Entity uid="9800">
 			<Template>gaia/tree/bush_temperate</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="267.65891" z="1280.49817"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="59306"/>
 		</Entity>
 		<Entity uid="9801">
 			<Template>gaia/tree/bush_temperate</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="257.91361" z="1274.00977"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="30563"/>
 		</Entity>
 		<Entity uid="9802">
 			<Template>gaia/tree/bush_temperate</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="246.88831" z="1258.28003"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="16902"/>
 		</Entity>
 		<Entity uid="9803">
 			<Template>gaia/tree/bush_temperate</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="238.18464" z="1309.68982"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="14316"/>
 		</Entity>
 		<Entity uid="9804">
 			<Template>gaia/tree/bush_temperate</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="230.23694" z="1304.84314"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="35041"/>
 		</Entity>
 		<Entity uid="9805">
 			<Template>gaia/tree/bush_temperate</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="220.2042" z="1295.04163"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="24517"/>
 		</Entity>
 		<Entity uid="9806">
 			<Template>gaia/tree/bush_temperate</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="222.64994" z="1280.56653"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="31927"/>
 		</Entity>
 		<Entity uid="9807">
 			<Template>gaia/tree/bush_temperate</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="232.36283" z="1269.67981"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="42280"/>
 		</Entity>
 		<Entity uid="9808">
 			<Template>gaia/tree/bush_temperate</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="241.86384" z="1253.76075"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="30348"/>
 		</Entity>
 		<Entity uid="9809">
 			<Template>gaia/tree/bush_temperate</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="259.33948" z="1271.71314"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="15070"/>
 		</Entity>
 		<Entity uid="9810">
 			<Template>gaia/tree/bush_temperate</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="242.05561" z="1314.35096"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="12876"/>
 		</Entity>
 		<Entity uid="9811">
 			<Template>gaia/tree/cypress</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="256.72812" z="1327.86438"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="49427"/>
 		</Entity>
 		<Entity uid="9812">
 			<Template>gaia/tree/cypress</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="269.06791" z="1339.61866"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="19295"/>
 		</Entity>
 		<Entity uid="9813">
 			<Template>gaia/tree/cypress</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="226.18058" z="1342.45911"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="23548"/>
 		</Entity>
 		<Entity uid="9814">
 			<Template>gaia/tree/cypress</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="254.80951" z="1359.37354"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="31448"/>
 		</Entity>
 		<Entity uid="9815">
 			<Template>gaia/tree/cypress</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="295.25766" z="1318.00757"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="30396"/>
 		</Entity>
 		<Entity uid="9816">
 			<Template>gaia/tree/cypress</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="297.19983" z="1315.5741"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="47579"/>
 		</Entity>
 		<Entity uid="9817">
 			<Template>gaia/tree/cypress</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="295.33542" z="1304.47974"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="59816"/>
 		</Entity>
 		<Entity uid="9818">
 			<Template>gaia/tree/cypress</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="291.65271" z="1302.95777"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="57851"/>
 		</Entity>
 		<Entity uid="9819">
 			<Template>gaia/tree/cypress</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="258.55808" z="1329.54517"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="50209"/>
 		</Entity>
 		<Entity uid="9820">
 			<Template>gaia/tree/cypress</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="240.68137" z="1323.0558"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="45820"/>
 		</Entity>
 		<Entity uid="9821">
 			<Template>gaia/tree/cypress</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="242.00065" z="1362.4928"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="43864"/>
 		</Entity>
 		<Entity uid="9822">
 			<Template>gaia/tree/poplar_lombardy</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="228.53693" z="1339.62073"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="64951"/>
 		</Entity>
 		<Entity uid="9823">
 			<Template>gaia/tree/poplar_lombardy</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="272.28248" z="1342.05811"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="33326"/>
 		</Entity>
 		<Entity uid="9824">
 			<Template>gaia/tree/bush_temperate</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="235.97703" z="1327.59888"/>
 			<Orientation y="1.45678"/>
 			<Actor seed="16252"/>
 		</Entity>
 		<Entity uid="9825">
 			<Template>gaia/tree/bush_temperate</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="285.70716" z="1326.28992"/>
 			<Orientation y="0.17774"/>
 			<Actor seed="4635"/>
 		</Entity>
 		<Entity uid="9826">
 			<Template>gaia/tree/bush_temperate</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="282.07013" z="1294.99427"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="10617"/>
 		</Entity>
 		<Entity uid="9827">
 			<Template>gaia/tree/bush_temperate</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="261.69025" z="1332.48597"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="57707"/>
 		</Entity>
 		<Entity uid="9828">
 			<Template>gaia/tree/bush_temperate</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="265.53199" z="1334.99805"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="25132"/>
 		</Entity>
 		<Entity uid="9829">
 			<Template>gaia/tree/bush_temperate</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="252.94761" z="1326.40955"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="33243"/>
 		</Entity>
 		<Entity uid="9830">
 			<Template>gaia/tree/bush_temperate</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="265.24518" z="1350.2942"/>
 			<Orientation y="0.25643"/>
 			<Actor seed="4062"/>
 		</Entity>
 		<Entity uid="9831">
 			<Template>gaia/tree/bush_temperate</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="248.27161" z="1366.39368"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="20115"/>
 		</Entity>
 		<Entity uid="9832">
 			<Template>gaia/tree/bush_temperate</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="225.23166" z="1345.38721"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="35870"/>
 		</Entity>
 		<Entity uid="9833">
 			<Template>gaia/tree/bush_temperate</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="231.8488" z="1351.38086"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="46374"/>
 		</Entity>
 		<Entity uid="9834">
 			<Template>gaia/tree/bush_temperate</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="247.87308" z="1319.1277"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="20893"/>
 		</Entity>
 		<Entity uid="9835">
 			<Template>gaia/tree/bush_temperate</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="285.9734" z="1299.54102"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="45462"/>
 		</Entity>
 		<Entity uid="9836">
 			<Template>gaia/tree/bush_temperate</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="276.25293" z="1336.52588"/>
 			<Orientation y="-2.40987"/>
 			<Actor seed="59757"/>
 		</Entity>
 		<Entity uid="9837">
 			<Template>gaia/tree/cretan_date_palm_short</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="231.01017" z="1334.75709"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="3009"/>
 		</Entity>
 		<Entity uid="9838">
 			<Template>gaia/tree/cretan_date_palm_short</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="249.30622" z="1320.78602"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="23559"/>
 		</Entity>
 		<Entity uid="9839">
 			<Template>gaia/tree/cretan_date_palm_short</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="299.37818" z="1308.84644"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="18542"/>
 		</Entity>
 		<Entity uid="9840">
 			<Template>gaia/tree/cretan_date_palm_short</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="270.6879" z="1345.8938"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="62359"/>
 		</Entity>
 		<Entity uid="9841">
 			<Template>gaia/tree/cretan_date_palm_short</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="234.27833" z="1355.05933"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="38355"/>
 		</Entity>
 		<Entity uid="9842">
 			<Template>gaia/tree/cretan_date_palm_short</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="245.3495" z="1364.84034"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="1599"/>
 		</Entity>
 		<Entity uid="9843">
 			<Template>gaia/tree/cretan_date_palm_short</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="276.77863" z="1291.55335"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="20349"/>
 		</Entity>
 		<Entity uid="9849">
 			<Template>gaia/fruit/berry_01</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="290.96552" z="1311.64795"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="45853"/>
 		</Entity>
 		<Entity uid="9850">
 			<Template>gaia/fruit/berry_01</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="285.48011" z="1306.93604"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="60963"/>
 		</Entity>
 		<Entity uid="9851">
 			<Template>gaia/fruit/berry_01</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="280.45167" z="1302.60413"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="8179"/>
 		</Entity>
 		<Entity uid="9852">
 			<Template>gaia/fruit/berry_01</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="275.1266" z="1297.82203"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="34726"/>
 		</Entity>
 		<Entity uid="9856">
 			<Template>gaia/fruit/berry_01</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="269.67829" z="1304.11683"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="56110"/>
 		</Entity>
 		<Entity uid="9857">
 			<Template>gaia/fruit/berry_01</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="263.46549" z="1310.52466"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="24716"/>
 		</Entity>
 		<Entity uid="9858">
 			<Template>gaia/fruit/berry_01</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="256.95322" z="1317.19446"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="54943"/>
 		</Entity>
 		<Entity uid="9859">
 			<Template>gaia/fruit/berry_01</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="275.48691" z="1308.98426"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="5531"/>
 		</Entity>
 		<Entity uid="9860">
 			<Template>gaia/fruit/berry_01</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="269.42939" z="1315.38965"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="19669"/>
 		</Entity>
 		<Entity uid="9861">
 			<Template>gaia/fruit/berry_01</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="263.26963" z="1321.99378"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="15529"/>
 		</Entity>
 		<Entity uid="9862">
 			<Template>gaia/fruit/berry_01</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="280.2082" z="1313.25831"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="6687"/>
 		</Entity>
 		<Entity uid="9863">
 			<Template>gaia/fruit/berry_01</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="274.31168" z="1320.34546"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="26603"/>
 		</Entity>
 		<Entity uid="9864">
 			<Template>gaia/fruit/berry_01</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="267.63941" z="1327.47364"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="58880"/>
 		</Entity>
 		<Entity uid="9865">
 			<Template>gaia/fruit/berry_01</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="285.85279" z="1317.82898"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="49067"/>
 		</Entity>
 		<Entity uid="9866">
 			<Template>gaia/fruit/berry_01</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="279.46985" z="1324.24207"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="34157"/>
 		</Entity>
 		<Entity uid="9867">
 			<Template>gaia/fruit/berry_01</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="271.96055" z="1332.26673"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="61346"/>
 		</Entity>
 		<Entity uid="9868">
 			<Template>gaia/fruit/grapes</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="260.56785" z="1284.40711"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="45343"/>
 		</Entity>
 		<Entity uid="9869">
 			<Template>gaia/fruit/grapes</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="255.74418" z="1279.80384"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="39053"/>
 		</Entity>
 		<Entity uid="9870">
 			<Template>gaia/fruit/grapes</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="251.79694" z="1274.85132"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="11632"/>
 		</Entity>
 		<Entity uid="9871">
 			<Template>gaia/fruit/grapes</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="247.0106" z="1270.0464"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="33826"/>
 		</Entity>
 		<Entity uid="9872">
 			<Template>gaia/fruit/grapes</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="241.75718" z="1265.76954"/>
 			<Orientation y="1.85065"/>
 			<Actor seed="29209"/>
 		</Entity>
 		<Entity uid="9873">
 			<Template>gaia/fruit/grapes</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="256.26633" z="1289.65833"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="61220"/>
 		</Entity>
 		<Entity uid="9874">
 			<Template>gaia/fruit/grapes</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="251.36393" z="1284.4192"/>
 			<Orientation y="0.89946"/>
 			<Actor seed="20196"/>
 		</Entity>
 		<Entity uid="9875">
 			<Template>gaia/fruit/grapes</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="246.42478" z="1280.36585"/>
 			<Orientation y="7.68297"/>
 			<Actor seed="16100"/>
 		</Entity>
 		<Entity uid="9876">
 			<Template>gaia/fruit/grapes</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="241.33527" z="1275.41724"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="33332"/>
 		</Entity>
 		<Entity uid="9877">
 			<Template>gaia/fruit/grapes</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="235.95905" z="1271.81885"/>
 			<Orientation y="1.93677"/>
 			<Actor seed="57825"/>
 		</Entity>
 		<Entity uid="9878">
 			<Template>gaia/fruit/grapes</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="252.63495" z="1295.49793"/>
 			<Orientation y="2.52601"/>
 			<Actor seed="19840"/>
 		</Entity>
 		<Entity uid="9879">
 			<Template>gaia/fruit/grapes</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="247.4357" z="1290.71497"/>
 			<Orientation y="0.6929"/>
 			<Actor seed="41623"/>
 		</Entity>
 		<Entity uid="9880">
 			<Template>gaia/fruit/grapes</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="242.28382" z="1285.92457"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="52144"/>
 		</Entity>
 		<Entity uid="9881">
 			<Template>gaia/fruit/grapes</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="236.77216" z="1281.65076"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="6830"/>
 		</Entity>
 		<Entity uid="9882">
 			<Template>gaia/fruit/grapes</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="231.0019" z="1277.92286"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="23786"/>
 		</Entity>
 		<Entity uid="9883">
 			<Template>gaia/fruit/grapes</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="247.77793" z="1301.41956"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="15907"/>
 		</Entity>
 		<Entity uid="9884">
 			<Template>gaia/fruit/grapes</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="242.4722" z="1295.912"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="58687"/>
 		</Entity>
 		<Entity uid="9885">
 			<Template>gaia/fruit/grapes</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="237.2277" z="1291.44397"/>
 			<Orientation y="2.97231"/>
 			<Actor seed="46134"/>
 		</Entity>
 		<Entity uid="9886">
 			<Template>gaia/fruit/grapes</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="232.5008" z="1286.86084"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="11155"/>
 		</Entity>
 		<Entity uid="9887">
 			<Template>gaia/fruit/grapes</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="226.62851" z="1283.65064"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="6293"/>
 		</Entity>
 		<Entity uid="9888">
 			<Template>gaia/fruit/grapes</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="243.57465" z="1307.39136"/>
 			<Orientation y="1.93975"/>
 			<Actor seed="20934"/>
 		</Entity>
 		<Entity uid="9889">
 			<Template>gaia/fruit/grapes</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="237.10608" z="1301.57422"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="43253"/>
 		</Entity>
 		<Entity uid="9890">
 			<Template>gaia/fruit/grapes</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="231.60114" z="1297.0464"/>
 			<Orientation y="1.74222"/>
 			<Actor seed="39206"/>
 		</Entity>
 		<Entity uid="9891">
 			<Template>gaia/fruit/grapes</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="227.3824" z="1292.07532"/>
 			<Orientation y="-2.57049"/>
 			<Actor seed="62489"/>
 		</Entity>
 		<Entity uid="9892">
 			<Template>gaia/fruit/grapes</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="222.50849" z="1288.19666"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="7888"/>
@@ -51400,343 +51400,343 @@
 		</Entity>
 		<Entity uid="9896">
 			<Template>gaia/tree/cypress</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="302.75553" z="1355.58277"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="56937"/>
 		</Entity>
 		<Entity uid="9897">
 			<Template>gaia/tree/cypress</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="318.36768" z="1344.17298"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="39453"/>
 		</Entity>
 		<Entity uid="9898">
 			<Template>gaia/tree/cypress</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="320.84821" z="1342.51978"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="261"/>
 		</Entity>
 		<Entity uid="9899">
 			<Template>gaia/tree/cypress</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="292.61762" z="1256.5918"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="20306"/>
 		</Entity>
 		<Entity uid="9900">
 			<Template>gaia/tree/cypress</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="274.61823" z="1239.32984"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="36505"/>
 		</Entity>
 		<Entity uid="9901">
 			<Template>gaia/tree/cypress</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="276.56809" z="1242.34986"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="47798"/>
 		</Entity>
 		<Entity uid="9902">
 			<Template>gaia/tree/cypress</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="257.65519" z="1245.88733"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="52280"/>
 		</Entity>
 		<Entity uid="9903">
 			<Template>gaia/tree/cypress</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="220.7378" z="1341.27149"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="12962"/>
 		</Entity>
 		<Entity uid="9904">
 			<Template>gaia/tree/cypress</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="209.68683" z="1327.69495"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="41774"/>
 		</Entity>
 		<Entity uid="9905">
 			<Template>gaia/tree/cypress</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="205.38337" z="1324.12012"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="46907"/>
 		</Entity>
 		<Entity uid="9906">
 			<Template>gaia/tree/cypress</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="292.84375" z="1361.28602"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="35732"/>
 		</Entity>
 		<Entity uid="9907">
 			<Template>gaia/tree/cypress</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="287.22385" z="1353.93274"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="96"/>
 		</Entity>
 		<Entity uid="9908">
 			<Template>gaia/tree/cypress</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="275.7165" z="1344.68006"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="63145"/>
 		</Entity>
 		<Entity uid="9909">
 			<Template>gaia/tree/bush_temperate</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="311.27402" z="1349.3064"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="32086"/>
 		</Entity>
 		<Entity uid="9910">
 			<Template>gaia/tree/bush_temperate</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="321.20411" z="1339.64893"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="8048"/>
 		</Entity>
 		<Entity uid="9911">
 			<Template>gaia/tree/bush_temperate</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="316.60163" z="1333.07947"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="19745"/>
 		</Entity>
 		<Entity uid="9912">
 			<Template>gaia/tree/bush_temperate</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="282.39219" z="1346.9856"/>
 			<Orientation y="-0.99398"/>
 			<Actor seed="61836"/>
 		</Entity>
 		<Entity uid="9913">
 			<Template>gaia/tree/bush_temperate</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="237.6211" z="1360.0011"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="44311"/>
 		</Entity>
 		<Entity uid="9914">
 			<Template>gaia/tree/bush_temperate</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="286.93787" z="1247.05347"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="42935"/>
 		</Entity>
 		<Entity uid="9915">
 			<Template>gaia/tree/bush_temperate</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="269.3217" z="1237.42725"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="56407"/>
 		</Entity>
 		<Entity uid="9916">
 			<Template>gaia/tree/bush_temperate</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="276.6709" z="1272.14161"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="47482"/>
 		</Entity>
 		<Entity uid="9917">
 			<Template>gaia/tree/bush_temperate</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="282.64847" z="1267.2273"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="18622"/>
 		</Entity>
 		<Entity uid="9918">
 			<Template>gaia/tree/bush_temperate</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="217.7938" z="1300.18421"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="14976"/>
 		</Entity>
 		<Entity uid="9919">
 			<Template>gaia/tree/bush_temperate</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="238.4835" z="1260.00538"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="9399"/>
 		</Entity>
 		<Entity uid="9920">
 			<Template>gaia/tree/cretan_date_palm_short</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="279.6114" z="1268.74927"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="41013"/>
 		</Entity>
 		<Entity uid="9921">
 			<Template>gaia/tree/cretan_date_palm_short</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="265.3968" z="1237.95472"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="10491"/>
 		</Entity>
 		<Entity uid="9922">
 			<Template>gaia/tree/cretan_date_palm_short</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="217.25843" z="1302.12989"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="27776"/>
 		</Entity>
 		<Entity uid="9923">
 			<Template>gaia/tree/cretan_date_palm_short</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="310.1915" z="1354.65589"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="17286"/>
 		</Entity>
 		<Entity uid="9925">
 			<Template>gaia/fauna_rabbit</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="1688.32398" z="988.78296"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="64858"/>
 		</Entity>
 		<Entity uid="9926">
 			<Template>gaia/fauna_rabbit</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="1709.20228" z="999.15503"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="64880"/>
 		</Entity>
 		<Entity uid="9927">
 			<Template>gaia/fauna_rabbit</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="1711.98377" z="1008.04157"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="25558"/>
 		</Entity>
 		<Entity uid="9928">
 			<Template>gaia/fauna_wolf</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="1895.56775" z="1446.94507"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="58400"/>
 		</Entity>
 		<Entity uid="9929">
 			<Template>gaia/fauna_wolf</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="1954.27405" z="1294.73804"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="8605"/>
 		</Entity>
 		<Entity uid="9930">
 			<Template>gaia/fruit/berry_01</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="1804.61634" z="982.13135"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="14616"/>
 		</Entity>
 		<Entity uid="9931">
 			<Template>gaia/fruit/berry_01</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="1795.61329" z="976.52308"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="60707"/>
 		</Entity>
 		<Entity uid="9932">
 			<Template>gaia/fruit/berry_01</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="1790.57447" z="987.43543"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="63646"/>
 		</Entity>
 		<Entity uid="9933">
 			<Template>gaia/fruit/berry_01</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="1646.35486" z="1143.16102"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="50461"/>
 		</Entity>
 		<Entity uid="9934">
 			<Template>gaia/fruit/berry_01</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="1635.48877" z="1149.11475"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="65345"/>
 		</Entity>
 		<Entity uid="9935">
 			<Template>gaia/fruit/berry_01</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="1628.82837" z="1137.0912"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="40652"/>
 		</Entity>
 		<Entity uid="9936">
 			<Template>gaia/fruit/berry_01</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="1679.00525" z="1331.72901"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="53147"/>
 		</Entity>
 		<Entity uid="9937">
 			<Template>gaia/fruit/berry_01</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="1693.19861" z="1329.04078"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="35630"/>
 		</Entity>
 		<Entity uid="9938">
 			<Template>gaia/fruit/berry_01</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="1684.86146" z="1325.36573"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="25577"/>
 		</Entity>
 		<Entity uid="9939">
 			<Template>gaia/fruit/berry_01</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="1773.23377" z="1467.52332"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="7245"/>
 		</Entity>
 		<Entity uid="9940">
 			<Template>gaia/fruit/berry_01</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="1759.79029" z="1464.22315"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="12793"/>
 		</Entity>
 		<Entity uid="9941">
 			<Template>gaia/fruit/berry_01</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="1526.49585" z="1012.11329"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="40151"/>
 		</Entity>
 		<Entity uid="9942">
 			<Template>gaia/fruit/berry_01</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="1536.7898" z="1009.05225"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="21714"/>
 		</Entity>
 		<Entity uid="9943">
 			<Template>gaia/fruit/berry_01</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="1537.99134" z="1017.31348"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="47675"/>
 		</Entity>
 		<Entity uid="9944">
 			<Template>gaia/fruit/berry_01</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="1535.74268" z="1017.31348"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="59427"/>
 		</Entity>
 		<Entity uid="9945">
 			<Template>gaia/fruit/berry_01</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="1519.48426" z="1010.5774"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="8401"/>

--- a/maps/scenarios/paradise_valley.xml
+++ b/maps/scenarios/paradise_valley.xml
@@ -8194,7 +8194,7 @@
 		</Entity>
 		<Entity uid="1431">
 			<Template>gaia/tree/oak_dead</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="550.17078" z="408.35236"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="27620"/>
@@ -8215,56 +8215,56 @@
 		</Entity>
 		<Entity uid="1434">
 			<Template>gaia/tree/oak_dead</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="551.922" z="432.76844"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="55201"/>
 		</Entity>
 		<Entity uid="1435">
 			<Template>gaia/tree/oak_dead</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="557.04407" z="438.92283"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="45725"/>
 		</Entity>
 		<Entity uid="1436">
 			<Template>gaia/tree/oak_dead</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="543.65809" z="431.07221"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="36880"/>
 		</Entity>
 		<Entity uid="1437">
 			<Template>gaia/tree/oak_dead</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="548.248" z="459.94672"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="58444"/>
 		</Entity>
 		<Entity uid="1438">
 			<Template>gaia/tree/oak_dead</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="557.62153" z="463.82306"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="4309"/>
 		</Entity>
 		<Entity uid="1439">
 			<Template>gaia/tree/oak_dead</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="560.235" z="475.11097"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="19274"/>
 		</Entity>
 		<Entity uid="1440">
 			<Template>gaia/tree/oak_dead</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="551.70252" z="472.56312"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="25930"/>
 		</Entity>
 		<Entity uid="1441">
 			<Template>gaia/tree/oak_dead</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="551.65308" z="445.87653"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="41220"/>
@@ -9139,7 +9139,7 @@
 		</Entity>
 		<Entity uid="1572">
 			<Template>gaia/tree/oak_dead</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="288.59217" z="707.8465"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="43242"/>
@@ -10273,287 +10273,287 @@
 		</Entity>
 		<Entity uid="1755">
 			<Template>gaia/fauna_chicken</Template>
-			<Player>4</Player>
+			<Player>0</Player>
 			<Position x="739.47028" z="1095.64942"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="4462"/>
 		</Entity>
 		<Entity uid="1756">
 			<Template>gaia/fauna_chicken</Template>
-			<Player>4</Player>
+			<Player>0</Player>
 			<Position x="746.78693" z="1107.94178"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="59744"/>
 		</Entity>
 		<Entity uid="1757">
 			<Template>gaia/fauna_chicken</Template>
-			<Player>4</Player>
+			<Player>0</Player>
 			<Position x="742.11506" z="1104.45643"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="5576"/>
 		</Entity>
 		<Entity uid="1758">
 			<Template>gaia/fauna_chicken</Template>
-			<Player>4</Player>
+			<Player>0</Player>
 			<Position x="744.31611" z="1098.28614"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="60109"/>
 		</Entity>
 		<Entity uid="1759">
 			<Template>gaia/fauna_chicken</Template>
-			<Player>4</Player>
+			<Player>0</Player>
 			<Position x="738.13624" z="1101.45655"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="17707"/>
 		</Entity>
 		<Entity uid="1760">
 			<Template>gaia/fauna_chicken</Template>
-			<Player>4</Player>
+			<Player>0</Player>
 			<Position x="733.62647" z="1090.58082"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="15711"/>
 		</Entity>
 		<Entity uid="1761">
 			<Template>gaia/fauna_chicken</Template>
-			<Player>4</Player>
+			<Player>0</Player>
 			<Position x="738.45716" z="1090.47999"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="37391"/>
 		</Entity>
 		<Entity uid="1762">
 			<Template>gaia/fauna_chicken</Template>
-			<Player>4</Player>
+			<Player>0</Player>
 			<Position x="733.29004" z="1098.52112"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="23912"/>
 		</Entity>
 		<Entity uid="1763">
 			<Template>gaia/fauna_chicken</Template>
-			<Player>4</Player>
+			<Player>0</Player>
 			<Position x="735.32184" z="1104.97938"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="34346"/>
 		</Entity>
 		<Entity uid="1764">
 			<Template>gaia/fauna_chicken</Template>
-			<Player>4</Player>
+			<Player>0</Player>
 			<Position x="741.82953" z="1103.8722"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="28740"/>
 		</Entity>
 		<Entity uid="1765">
 			<Template>gaia/fauna_chicken</Template>
-			<Player>4</Player>
+			<Player>0</Player>
 			<Position x="737.94544" z="1110.46717"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="49527"/>
 		</Entity>
 		<Entity uid="1766">
 			<Template>gaia/fauna_chicken</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="1095.28736" z="495.43012"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="60971"/>
 		</Entity>
 		<Entity uid="1767">
 			<Template>gaia/fauna_chicken</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="1101.5243" z="495.22428"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="38603"/>
 		</Entity>
 		<Entity uid="1768">
 			<Template>gaia/fauna_chicken</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="1097.99207" z="503.71702"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="43665"/>
 		</Entity>
 		<Entity uid="1769">
 			<Template>gaia/fauna_chicken</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="1092.73292" z="501.38523"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="28619"/>
 		</Entity>
 		<Entity uid="1770">
 			<Template>gaia/fauna_chicken</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="1098.09913" z="498.51035"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="33399"/>
 		</Entity>
 		<Entity uid="1771">
 			<Template>gaia/fauna_chicken</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="1092.16907" z="494.62552"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="56509"/>
 		</Entity>
 		<Entity uid="1772">
 			<Template>gaia/fauna_chicken</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="1097.43897" z="489.70698"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="37183"/>
 		</Entity>
 		<Entity uid="1773">
 			<Template>gaia/fauna_chicken</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="1086.2334" z="494.8802"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="58023"/>
 		</Entity>
 		<Entity uid="1774">
 			<Template>gaia/fauna_chicken</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="1087.94898" z="488.13184"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="42221"/>
 		</Entity>
 		<Entity uid="1775">
 			<Template>gaia/fauna_chicken</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="1089.59156" z="497.7274"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="46445"/>
 		</Entity>
 		<Entity uid="1776">
 			<Template>gaia/fauna_chicken</Template>
-			<Player>3</Player>
+			<Player>0</Player>
 			<Position x="123.50568" z="425.0525"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="62185"/>
 		</Entity>
 		<Entity uid="1777">
 			<Template>gaia/fauna_chicken</Template>
-			<Player>3</Player>
+			<Player>0</Player>
 			<Position x="132.20224" z="432.27768"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="42303"/>
 		</Entity>
 		<Entity uid="1778">
 			<Template>gaia/fauna_chicken</Template>
-			<Player>3</Player>
+			<Player>0</Player>
 			<Position x="129.25086" z="426.05622"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="56343"/>
 		</Entity>
 		<Entity uid="1779">
 			<Template>gaia/fauna_chicken</Template>
-			<Player>3</Player>
+			<Player>0</Player>
 			<Position x="125.56733" z="428.62745"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="39376"/>
 		</Entity>
 		<Entity uid="1780">
 			<Template>gaia/fauna_chicken</Template>
-			<Player>3</Player>
+			<Player>0</Player>
 			<Position x="129.70057" z="435.88895"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="17812"/>
 		</Entity>
 		<Entity uid="1781">
 			<Template>gaia/fauna_chicken</Template>
-			<Player>3</Player>
+			<Player>0</Player>
 			<Position x="131.43702" z="423.33973"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="53782"/>
 		</Entity>
 		<Entity uid="1782">
 			<Template>gaia/fauna_chicken</Template>
-			<Player>3</Player>
+			<Player>0</Player>
 			<Position x="133.06336" z="428.62488"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="30037"/>
 		</Entity>
 		<Entity uid="1783">
 			<Template>gaia/fauna_chicken</Template>
-			<Player>3</Player>
+			<Player>0</Player>
 			<Position x="127.29394" z="421.10892"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="14765"/>
 		</Entity>
 		<Entity uid="1784">
 			<Template>gaia/fauna_chicken</Template>
-			<Player>3</Player>
+			<Player>0</Player>
 			<Position x="128.47129" z="428.73044"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="46861"/>
 		</Entity>
 		<Entity uid="1785">
 			<Template>gaia/fauna_chicken</Template>
-			<Player>3</Player>
+			<Player>0</Player>
 			<Position x="134.93244" z="436.66117"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="60928"/>
 		</Entity>
 		<Entity uid="1786">
 			<Template>gaia/fauna_chicken</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="316.61759" z="336.1201"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="13698"/>
 		</Entity>
 		<Entity uid="1787">
 			<Template>gaia/fauna_chicken</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="328.73163" z="339.61268"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="4478"/>
 		</Entity>
 		<Entity uid="1788">
 			<Template>gaia/fauna_chicken</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="326.51511" z="331.5918"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="51345"/>
 		</Entity>
 		<Entity uid="1789">
 			<Template>gaia/fauna_chicken</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="322.94275" z="336.08622"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="17973"/>
 		</Entity>
 		<Entity uid="1790">
 			<Template>gaia/fauna_chicken</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="317.8209" z="330.84873"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="20593"/>
 		</Entity>
 		<Entity uid="1791">
 			<Template>gaia/fauna_chicken</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="323.01221" z="342.7761"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="61269"/>
 		</Entity>
 		<Entity uid="1792">
 			<Template>gaia/fauna_chicken</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="337.20414" z="338.39847"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="16189"/>
 		</Entity>
 		<Entity uid="1793">
 			<Template>gaia/fauna_chicken</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="330.48292" z="330.49766"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="41838"/>
 		</Entity>
 		<Entity uid="1794">
 			<Template>gaia/fauna_chicken</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="333.17508" z="338.42093"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="40170"/>
 		</Entity>
 		<Entity uid="1795">
 			<Template>gaia/fauna_chicken</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="332.69068" z="342.84778"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="54745"/>

--- a/maps/scenarios/qart_hadasht.xml
+++ b/maps/scenarios/qart_hadasht.xml
@@ -387,7 +387,7 @@
 		</Entity>
 		<Entity uid="86">
 			<Template>gaia/fauna_horse</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="913.47687" z="613.61744"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="48998"/>
@@ -408,840 +408,840 @@
 		</Entity>
 		<Entity uid="89">
 			<Template>gaia/fauna_peacock</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="964.73353" z="428.5619"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="9420"/>
 		</Entity>
 		<Entity uid="90">
 			<Template>gaia/fauna_peacock</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="970.5074" z="415.23835"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="16130"/>
 		</Entity>
 		<Entity uid="91">
 			<Template>gaia/fauna_peacock</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="930.68317" z="398.80564"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="35570"/>
 		</Entity>
 		<Entity uid="92">
 			<Template>gaia/fauna_peacock</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="943.41955" z="381.17118"/>
 			<Orientation y="-2.10515"/>
 			<Actor seed="58190"/>
 		</Entity>
 		<Entity uid="93">
 			<Template>gaia/tree/bush_temperate</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="982.1006" z="440.8827"/>
 			<Orientation y="2.67185"/>
 			<Actor seed="28558"/>
 		</Entity>
 		<Entity uid="94">
 			<Template>gaia/tree/bush_temperate</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="988.87446" z="443.01801"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="13654"/>
 		</Entity>
 		<Entity uid="95">
 			<Template>gaia/tree/bush_temperate</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="994" z="443.97794"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="39236"/>
 		</Entity>
 		<Entity uid="96">
 			<Template>gaia/tree/bush_temperate</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="999.20734" z="444.08173"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="1288"/>
 		</Entity>
 		<Entity uid="97">
 			<Template>gaia/tree/bush_temperate</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="1001.48475" z="444.06778"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="21750"/>
 		</Entity>
 		<Entity uid="98">
 			<Template>gaia/tree/bush_temperate</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="1006.1908" z="443.77854"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="7648"/>
 		</Entity>
 		<Entity uid="99">
 			<Template>gaia/tree/bush_temperate</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="1008.92292" z="444.61167"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="49638"/>
 		</Entity>
 		<Entity uid="100">
 			<Template>gaia/tree/bush_temperate</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="1012.27021" z="443.52546"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="57070"/>
 		</Entity>
 		<Entity uid="101">
 			<Template>gaia/tree/bush_temperate</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="1007.87928" z="443.57325"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="56420"/>
 		</Entity>
 		<Entity uid="102">
 			<Template>gaia/tree/bush_temperate</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="1016.41456" z="443.10758"/>
 			<Orientation y="2.93772"/>
 			<Actor seed="5810"/>
 		</Entity>
 		<Entity uid="103">
 			<Template>gaia/tree/bush_temperate</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="1023.27076" z="441.36896"/>
 			<Orientation y="-3.07102"/>
 			<Actor seed="48800"/>
 		</Entity>
 		<Entity uid="104">
 			<Template>gaia/tree/bush_temperate</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="1030.26661" z="439.1436"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="30134"/>
 		</Entity>
 		<Entity uid="105">
 			<Template>gaia/tree/bush_temperate</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="1033.19568" z="438.64329"/>
 			<Orientation y="-3.13164"/>
 			<Actor seed="43440"/>
 		</Entity>
 		<Entity uid="106">
 			<Template>gaia/tree/bush_temperate</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="1041.53602" z="435.4726"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="20578"/>
 		</Entity>
 		<Entity uid="107">
 			<Template>gaia/tree/bush_temperate</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="1040.00709" z="436.37458"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="10574"/>
 		</Entity>
 		<Entity uid="108">
 			<Template>gaia/tree/bush_temperate</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="1042.89454" z="434.32752"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="63722"/>
 		</Entity>
 		<Entity uid="109">
 			<Template>gaia/tree/bush_temperate</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="1046.39283" z="433.59507"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="46814"/>
 		</Entity>
 		<Entity uid="110">
 			<Template>gaia/tree/bush_temperate</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="1050.87488" z="431.5275"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="49928"/>
 		</Entity>
 		<Entity uid="111">
 			<Template>gaia/tree/bush_temperate</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="1053.00916" z="431.2764"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="59212"/>
 		</Entity>
 		<Entity uid="112">
 			<Template>gaia/tree/bush_temperate</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="1056.65931" z="430.69413"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="53140"/>
 		</Entity>
 		<Entity uid="113">
 			<Template>gaia/tree/bush_temperate</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="1059.84058" z="428.84546"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="2402"/>
 		</Entity>
 		<Entity uid="114">
 			<Template>gaia/tree/bush_temperate</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="1063.07276" z="428.1869"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="11876"/>
 		</Entity>
 		<Entity uid="115">
 			<Template>gaia/tree/bush_temperate</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="1065.0337" z="426.93488"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="51454"/>
 		</Entity>
 		<Entity uid="116">
 			<Template>gaia/tree/bush_temperate</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="1067.23877" z="425.64338"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="55732"/>
 		</Entity>
 		<Entity uid="117">
 			<Template>gaia/tree/bush_temperate</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="1064.29261" z="428.30637"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="36334"/>
 		</Entity>
 		<Entity uid="118">
 			<Template>gaia/tree/bush_temperate</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="1067.57618" z="423.57877"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="42630"/>
 		</Entity>
 		<Entity uid="119">
 			<Template>gaia/tree/bush_temperate</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="1069.36841" z="422.5926"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="33744"/>
 		</Entity>
 		<Entity uid="120">
 			<Template>gaia/tree/bush_temperate</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="1070.83436" z="421.70893"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="41494"/>
 		</Entity>
 		<Entity uid="121">
 			<Template>gaia/tree/bush_temperate</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="1072.4231" z="420.56809"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="8882"/>
 		</Entity>
 		<Entity uid="122">
 			<Template>gaia/tree/bush_temperate</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="1074.21009" z="419.57181"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="38132"/>
 		</Entity>
 		<Entity uid="123">
 			<Template>gaia/tree/bush_temperate</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="1074.61988" z="419.27387"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="20172"/>
 		</Entity>
 		<Entity uid="124">
 			<Template>gaia/tree/bush_temperate</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="1077.87916" z="417.85041"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="43208"/>
 		</Entity>
 		<Entity uid="125">
 			<Template>gaia/tree/bush_temperate</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="1070.62818" z="424.44187"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="22574"/>
 		</Entity>
 		<Entity uid="126">
 			<Template>gaia/tree/bush_temperate</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="1032.81897" z="431.51807"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="38490"/>
 		</Entity>
 		<Entity uid="127">
 			<Template>gaia/tree/bush_temperate</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="1037.0265" z="430.37391"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="59800"/>
 		</Entity>
 		<Entity uid="128">
 			<Template>gaia/tree/bush_temperate</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="1041.8777" z="428.24576"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="28150"/>
 		</Entity>
 		<Entity uid="129">
 			<Template>gaia/tree/bush_temperate</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="1046.76453" z="425.34452"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="61552"/>
 		</Entity>
 		<Entity uid="130">
 			<Template>gaia/tree/bush_temperate</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="1044.55713" z="425.97211"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="7336"/>
 		</Entity>
 		<Entity uid="131">
 			<Template>gaia/tree/bush_temperate</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="1042.48707" z="426.93421"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="22012"/>
 		</Entity>
 		<Entity uid="132">
 			<Template>gaia/tree/bush_temperate</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="1046.68409" z="421.68088"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="25954"/>
 		</Entity>
 		<Entity uid="133">
 			<Template>gaia/tree/bush_temperate</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="1049.92432" z="419.71436"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="42208"/>
 		</Entity>
 		<Entity uid="134">
 			<Template>gaia/tree/bush_temperate</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="1042.97669" z="429.067"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="15806"/>
 		</Entity>
 		<Entity uid="135">
 			<Template>gaia/tree/bush_temperate</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="1050.36963" z="423.94166"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="3062"/>
 		</Entity>
 		<Entity uid="136">
 			<Template>gaia/tree/bush_temperate</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="1053.87146" z="422.56321"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="31288"/>
 		</Entity>
 		<Entity uid="137">
 			<Template>gaia/tree/bush_temperate</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="1051.94361" z="424.57587"/>
 			<Orientation y="-1.16312"/>
 			<Actor seed="14990"/>
 		</Entity>
 		<Entity uid="138">
 			<Template>gaia/tree/bush_temperate</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="1042.05494" z="428.57395"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="38554"/>
 		</Entity>
 		<Entity uid="139">
 			<Template>gaia/tree/bush_temperate</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="1037.89271" z="428.211"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="61494"/>
 		</Entity>
 		<Entity uid="140">
 			<Template>gaia/tree/bush_temperate</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="1039.03467" z="424.1012"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="19338"/>
 		</Entity>
 		<Entity uid="141">
 			<Template>gaia/tree/bush_temperate</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="1042.19349" z="420.29261"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="27888"/>
 		</Entity>
 		<Entity uid="142">
 			<Template>gaia/tree/bush_temperate</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="1047.32679" z="418.23511"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="43764"/>
 		</Entity>
 		<Entity uid="143">
 			<Template>gaia/tree/bush_temperate</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="1051.02381" z="417.26987"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="54570"/>
 		</Entity>
 		<Entity uid="144">
 			<Template>gaia/tree/bush_temperate</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="1054.09205" z="417.51883"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="51496"/>
 		</Entity>
 		<Entity uid="145">
 			<Template>gaia/tree/bush_temperate</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="1058.40442" z="418.12153"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="46894"/>
 		</Entity>
 		<Entity uid="146">
 			<Template>gaia/tree/bush_temperate</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="1060.71497" z="422.37983"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="43376"/>
 		</Entity>
 		<Entity uid="147">
 			<Template>gaia/tree/bush_temperate</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="1055.05481" z="428.01703"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="52870"/>
 		</Entity>
 		<Entity uid="148">
 			<Template>gaia/tree/bush_temperate</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="1058.43567" z="424.45527"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="22800"/>
 		</Entity>
 		<Entity uid="149">
 			<Template>gaia/tree/bush_temperate</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="1061.67566" z="422.11652"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="33774"/>
 		</Entity>
 		<Entity uid="150">
 			<Template>gaia/tree/bush_temperate</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="1065.22046" z="419.83112"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="64580"/>
 		</Entity>
 		<Entity uid="151">
 			<Template>gaia/tree/bush_temperate</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="1066.85645" z="419.12226"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="8020"/>
 		</Entity>
 		<Entity uid="152">
 			<Template>gaia/tree/bush_temperate</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="1060.96167" z="416.78324"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="11606"/>
 		</Entity>
 		<Entity uid="153">
 			<Template>gaia/tree/bush_temperate</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="1056.59937" z="415.82581"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="52118"/>
 		</Entity>
 		<Entity uid="154">
 			<Template>gaia/tree/bush_temperate</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="1054.60621" z="416.33686"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="36442"/>
 		</Entity>
 		<Entity uid="155">
 			<Template>gaia/tree/bush_temperate</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="1060.46045" z="414.8766"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="2666"/>
 		</Entity>
 		<Entity uid="156">
 			<Template>gaia/tree/bush_temperate</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="1064.49427" z="415.63276"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="62092"/>
 		</Entity>
 		<Entity uid="157">
 			<Template>gaia/tree/bush_temperate</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="1067.5" z="416.67438"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="43286"/>
 		</Entity>
 		<Entity uid="158">
 			<Template>gaia/tree/bush_temperate</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="1070.71448" z="418.43317"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="11520"/>
 		</Entity>
 		<Entity uid="159">
 			<Template>gaia/tree/bush_temperate</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="1068.31849" z="415.55463"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="19842"/>
 		</Entity>
 		<Entity uid="160">
 			<Template>gaia/tree/bush_temperate</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="1062.78565" z="414.34653"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="32418"/>
 		</Entity>
 		<Entity uid="161">
 			<Template>gaia/tree/bush_temperate</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="1054.823" z="411.45868"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="60724"/>
 		</Entity>
 		<Entity uid="162">
 			<Template>gaia/tree/bush_temperate</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="1050.95826" z="412.71436"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="60940"/>
 		</Entity>
 		<Entity uid="163">
 			<Template>gaia/tree/bush_temperate</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="1034.89258" z="425.29172"/>
 			<Orientation y="2.30373"/>
 			<Actor seed="36540"/>
 		</Entity>
 		<Entity uid="164">
 			<Template>gaia/tree/bush_temperate</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="1042.03907" z="418.19428"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="43098"/>
 		</Entity>
 		<Entity uid="165">
 			<Template>gaia/tree/bush_temperate</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="1045.87806" z="414.71995"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="14410"/>
 		</Entity>
 		<Entity uid="166">
 			<Template>gaia/tree/bush_temperate</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="1036.66871" z="424.41498"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="642"/>
 		</Entity>
 		<Entity uid="167">
 			<Template>gaia/tree/bush_temperate</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="1076.34339" z="422.08475"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="33960"/>
 		</Entity>
 		<Entity uid="168">
 			<Template>gaia/tree/bush_temperate</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="1077.74964" z="420.36942"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="61228"/>
 		</Entity>
 		<Entity uid="169">
 			<Template>gaia/tree/bush_temperate</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="1081.38733" z="416.28827"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="41628"/>
 		</Entity>
 		<Entity uid="170">
 			<Template>gaia/tree/bush_temperate</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="1083.12977" z="414.1659"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="56770"/>
 		</Entity>
 		<Entity uid="171">
 			<Template>gaia/tree/bush_temperate</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="1084.52271" z="412.91388"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="8394"/>
 		</Entity>
 		<Entity uid="172">
 			<Template>gaia/tree/bush_temperate</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="1079.19703" z="419.67823"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="7078"/>
 		</Entity>
 		<Entity uid="173">
 			<Template>gaia/tree/bush_temperate</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="1084.03211" z="414.60645"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="31508"/>
 		</Entity>
 		<Entity uid="174">
 			<Template>gaia/tree/bush_temperate</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="1085.83094" z="413.71537"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="6442"/>
 		</Entity>
 		<Entity uid="175">
 			<Template>gaia/tree/bush_temperate</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="1087.7356" z="411.19047"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="33956"/>
 		</Entity>
 		<Entity uid="176">
 			<Template>gaia/tree/bush_temperate</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="1088.60877" z="408.58478"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="32862"/>
 		</Entity>
 		<Entity uid="177">
 			<Template>gaia/tree/bush_temperate</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="1088.66724" z="405.65137"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="9358"/>
 		</Entity>
 		<Entity uid="178">
 			<Template>gaia/tree/bush_temperate</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="1088.82264" z="403.58005"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="64578"/>
 		</Entity>
 		<Entity uid="179">
 			<Template>gaia/tree/bush_temperate</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="1089.25062" z="402.12494"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="2370"/>
 		</Entity>
 		<Entity uid="180">
 			<Template>gaia/tree/bush_temperate</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="1089.8932" z="399.94367"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="858"/>
 		</Entity>
 		<Entity uid="181">
 			<Template>gaia/tree/bush_temperate</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="1090.53858" z="395.13193"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="39334"/>
 		</Entity>
 		<Entity uid="182">
 			<Template>gaia/tree/bush_temperate</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="1090.27234" z="391.9738"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="4450"/>
 		</Entity>
 		<Entity uid="183">
 			<Template>gaia/tree/bush_temperate</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="1090.735" z="389.71171"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="8504"/>
 		</Entity>
 		<Entity uid="184">
 			<Template>gaia/tree/bush_temperate</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="1070.24732" z="417.53272"/>
 			<Orientation y="2.44491"/>
 			<Actor seed="38896"/>
 		</Entity>
 		<Entity uid="186">
 			<Template>gaia/tree/bush_temperate</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="1082.43885" z="407.86347"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="44760"/>
 		</Entity>
 		<Entity uid="187">
 			<Template>gaia/tree/bush_temperate</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="1085.55115" z="407.2533"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="23866"/>
 		</Entity>
 		<Entity uid="188">
 			<Template>gaia/tree/bush_temperate</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="1075.92066" z="416.37592"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="20786"/>
 		</Entity>
 		<Entity uid="189">
 			<Template>gaia/tree/bush_temperate</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="1072.45545" z="416.93299"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="11226"/>
 		</Entity>
 		<Entity uid="190">
 			<Template>gaia/tree/bush_temperate</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="1079.01063" z="412.37366"/>
 			<Orientation y="2.17655"/>
 			<Actor seed="56474"/>
 		</Entity>
 		<Entity uid="191">
 			<Template>gaia/tree/bush_temperate</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="1084.08436" z="409.22773"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="23314"/>
 		</Entity>
 		<Entity uid="192">
 			<Template>gaia/tree/bush_temperate</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="1084.32593" z="409.4105"/>
 			<Orientation y="-2.86576"/>
 			<Actor seed="46296"/>
 		</Entity>
 		<Entity uid="194">
 			<Template>gaia/tree/bush_temperate</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="1083.78882" z="392.8841"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="32348"/>
 		</Entity>
 		<Entity uid="195">
 			<Template>gaia/tree/bush_temperate</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="1009.51398" z="336.10584"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="59190"/>
 		</Entity>
 		<Entity uid="196">
 			<Template>gaia/tree/bush_temperate</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="967.5594" z="330.49463"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="30378"/>
 		</Entity>
 		<Entity uid="197">
 			<Template>gaia/tree/bush_temperate</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="1007.10975" z="332.1688"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="27186"/>
 		</Entity>
 		<Entity uid="198">
 			<Template>gaia/tree/bush_temperate</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="1034.41956" z="345.29224"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="10828"/>
 		</Entity>
 		<Entity uid="199">
 			<Template>gaia/tree/bush_temperate</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="1048.14856" z="362.53376"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="6342"/>
 		</Entity>
 		<Entity uid="200">
 			<Template>gaia/tree/bush_temperate</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="941.59662" z="348.6478"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="17502"/>
 		</Entity>
 		<Entity uid="202">
 			<Template>gaia/tree/bush_temperate</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="918.47693" z="334.54139"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="37930"/>
 		</Entity>
 		<Entity uid="203">
 			<Template>gaia/tree/bush_temperate</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="896.28693" z="381.8147"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="45084"/>
 		</Entity>
 		<Entity uid="204">
 			<Template>gaia/tree/bush_temperate</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="896.77283" z="378.98041"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="51722"/>
 		</Entity>
 		<Entity uid="205">
 			<Template>gaia/tree/bush_temperate</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="898.8509" z="373.91413"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="65242"/>
 		</Entity>
 		<Entity uid="206">
 			<Template>gaia/tree/bush_temperate</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="898.50116" z="370.07276"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="62714"/>
 		</Entity>
 		<Entity uid="207">
 			<Template>gaia/tree/bush_temperate</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="894.99115" z="375.9539"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="32718"/>
 		</Entity>
 		<Entity uid="208">
 			<Template>gaia/tree/bush_temperate</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="893.63172" z="378.93403"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="38666"/>
 		</Entity>
 		<Entity uid="209">
 			<Template>gaia/tree/bush_temperate</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="895.45398" z="373.26331"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="44050"/>
 		</Entity>
 		<Entity uid="210">
 			<Template>gaia/tree/bush_temperate</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="894.96503" z="371.43967"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="22312"/>
 		</Entity>
 		<Entity uid="211">
 			<Template>gaia/tree/bush_temperate</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="893.9723" z="364.6219"/>
 			<Orientation y="2.35621"/>
 			<Obstruction group="56"/>
@@ -1249,7 +1249,7 @@
 		</Entity>
 		<Entity uid="212">
 			<Template>gaia/tree/bush_temperate</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="894.67957" z="361.9756"/>
 			<Orientation y="2.35621"/>
 			<Obstruction group="56"/>
@@ -1257,7 +1257,7 @@
 		</Entity>
 		<Entity uid="213">
 			<Template>gaia/tree/bush_temperate</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="893.34668" z="366.18238"/>
 			<Orientation y="2.35621"/>
 			<Obstruction group="56"/>
@@ -1265,7 +1265,7 @@
 		</Entity>
 		<Entity uid="214">
 			<Template>gaia/tree/bush_temperate</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="890.27216" z="371.97495"/>
 			<Orientation y="2.35621"/>
 			<Obstruction group="56" group2="478"/>
@@ -1273,7 +1273,7 @@
 		</Entity>
 		<Entity uid="215">
 			<Template>gaia/tree/bush_temperate</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="892.29474" z="373.99454"/>
 			<Orientation y="2.35621"/>
 			<Obstruction group="56"/>
@@ -1281,56 +1281,56 @@
 		</Entity>
 		<Entity uid="216">
 			<Template>gaia/tree/bush_temperate</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="895.3368" z="370.29352"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="62896"/>
 		</Entity>
 		<Entity uid="217">
 			<Template>gaia/tree/bush_temperate</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="896.97535" z="368.1056"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="41300"/>
 		</Entity>
 		<Entity uid="218">
 			<Template>gaia/tree/bush_temperate</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="897.2541" z="364.41868"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="10432"/>
 		</Entity>
 		<Entity uid="219">
 			<Template>gaia/tree/bush_temperate</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="896.23536" z="361.83002"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="61520"/>
 		</Entity>
 		<Entity uid="220">
 			<Template>gaia/tree/bush_temperate</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="896.07184" z="359.39222"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="2442"/>
 		</Entity>
 		<Entity uid="221">
 			<Template>gaia/tree/bush_temperate</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="896.09791" z="358.86643"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="20998"/>
 		</Entity>
 		<Entity uid="222">
 			<Template>gaia/tree/bush_temperate</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="895.94397" z="361.0204"/>
 			<Orientation y="-0.09023"/>
 			<Actor seed="36982"/>
 		</Entity>
 		<Entity uid="223">
 			<Template>gaia/tree/bush_temperate</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="890.4253" z="376.76563"/>
 			<Orientation y="2.35621"/>
 			<Obstruction group="56"/>
@@ -1338,7 +1338,7 @@
 		</Entity>
 		<Entity uid="224">
 			<Template>gaia/tree/bush_temperate</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="890.19544" z="387.05668"/>
 			<Orientation y="2.35621"/>
 			<Obstruction group="57" group2="58"/>
@@ -1346,497 +1346,497 @@
 		</Entity>
 		<Entity uid="225">
 			<Template>gaia/tree/bush_temperate</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="894.13105" z="382.66895"/>
 			<Orientation y="2.77529"/>
 			<Actor seed="19678"/>
 		</Entity>
 		<Entity uid="226">
 			<Template>gaia/tree/bush_temperate</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="898.4344" z="374.29032"/>
 			<Orientation y="-3.09391"/>
 			<Actor seed="16876"/>
 		</Entity>
 		<Entity uid="227">
 			<Template>gaia/tree/bush_temperate</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="897.92896" z="366.24872"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="17014"/>
 		</Entity>
 		<Entity uid="228">
 			<Template>gaia/tree/bush_temperate</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="900.95557" z="360.97306"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="26400"/>
 		</Entity>
 		<Entity uid="229">
 			<Template>gaia/tree/bush_temperate</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="900.50672" z="356.36057"/>
 			<Orientation y="-3.06232"/>
 			<Actor seed="46630"/>
 		</Entity>
 		<Entity uid="230">
 			<Template>gaia/tree/bush_temperate</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="899.68982" z="350.9538"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="33390"/>
 		</Entity>
 		<Entity uid="231">
 			<Template>gaia/tree/bush_temperate</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="900.03205" z="351.19007"/>
 			<Orientation y="-0.10602"/>
 			<Actor seed="41054"/>
 		</Entity>
 		<Entity uid="232">
 			<Template>gaia/tree/bush_temperate</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="900.04072" z="360.1772"/>
 			<Orientation y="-0.3063"/>
 			<Actor seed="12704"/>
 		</Entity>
 		<Entity uid="233">
 			<Template>gaia/tree/bush_temperate</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="897.0448" z="368.86066"/>
 			<Orientation y="-0.11243"/>
 			<Actor seed="57990"/>
 		</Entity>
 		<Entity uid="234">
 			<Template>gaia/tree/bush_temperate</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="895.3313" z="382.7338"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="45092"/>
 		</Entity>
 		<Entity uid="236">
 			<Template>gaia/tree/bush_temperate</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="904.7823" z="362.1521"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="32650"/>
 		</Entity>
 		<Entity uid="237">
 			<Template>gaia/tree/bush_temperate</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="904.66797" z="361.4961"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="48592"/>
 		</Entity>
 		<Entity uid="238">
 			<Template>gaia/tree/bush_temperate</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="897.62598" z="384.74885"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="11702"/>
 		</Entity>
 		<Entity uid="239">
 			<Template>gaia/tree/bush_temperate</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="901.5641" z="378.78269"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="14518"/>
 		</Entity>
 		<Entity uid="240">
 			<Template>gaia/tree/bush_temperate</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="905.6919" z="371.48874"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="63226"/>
 		</Entity>
 		<Entity uid="242">
 			<Template>gaia/tree/bush_temperate</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="908.61585" z="365.41727"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="29298"/>
 		</Entity>
 		<Entity uid="243">
 			<Template>gaia/tree/bush_temperate</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="903.05127" z="378.77018"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="17032"/>
 		</Entity>
 		<Entity uid="245">
 			<Template>gaia/tree/bush_temperate</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="898.28333" z="386.23792"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="27252"/>
 		</Entity>
 		<Entity uid="246">
 			<Template>gaia/tree/bush_temperate</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="903.6637" z="375.60987"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="42744"/>
 		</Entity>
 		<Entity uid="247">
 			<Template>gaia/tree/bush_temperate</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="904.41114" z="372.13776"/>
 			<Orientation y="-3.10595"/>
 			<Actor seed="53356"/>
 		</Entity>
 		<Entity uid="248">
 			<Template>gaia/tree/bush_temperate</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="903.96528" z="360.82203"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="41576"/>
 		</Entity>
 		<Entity uid="249">
 			<Template>gaia/tree/bush_temperate</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="904.18659" z="358.91782"/>
 			<Orientation y="-3.02805"/>
 			<Actor seed="65361"/>
 		</Entity>
 		<Entity uid="250">
 			<Template>gaia/tree/bush_temperate</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="902.7237" z="351.88675"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="46690"/>
 		</Entity>
 		<Entity uid="251">
 			<Template>gaia/tree/bush_temperate</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="905.41419" z="349.29041"/>
 			<Orientation y="2.85813"/>
 			<Actor seed="54458"/>
 		</Entity>
 		<Entity uid="252">
 			<Template>gaia/tree/bush_temperate</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="905.02881" z="342.67734"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="10340"/>
 		</Entity>
 		<Entity uid="253">
 			<Template>gaia/tree/bush_temperate</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="905.23963" z="342.10984"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="13612"/>
 		</Entity>
 		<Entity uid="254">
 			<Template>gaia/tree/bush_temperate</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="902.13825" z="348.82099"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="15334"/>
 		</Entity>
 		<Entity uid="255">
 			<Template>gaia/tree/bush_temperate</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="903.49488" z="352.03525"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="21352"/>
 		</Entity>
 		<Entity uid="256">
 			<Template>gaia/tree/bush_temperate</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="906.65137" z="351.58948"/>
 			<Orientation y="2.80446"/>
 			<Actor seed="61740"/>
 		</Entity>
 		<Entity uid="257">
 			<Template>gaia/tree/bush_temperate</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="909.25257" z="342.07456"/>
 			<Orientation y="-0.00214"/>
 			<Actor seed="46310"/>
 		</Entity>
 		<Entity uid="258">
 			<Template>gaia/tree/bush_temperate</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="910.29841" z="352.26572"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="13576"/>
 		</Entity>
 		<Entity uid="259">
 			<Template>gaia/tree/bush_temperate</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="908.77906" z="356.22941"/>
 			<Orientation y="2.96525"/>
 			<Actor seed="60304"/>
 		</Entity>
 		<Entity uid="260">
 			<Template>gaia/tree/bush_temperate</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="910.04206" z="344.52155"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="55434"/>
 		</Entity>
 		<Entity uid="261">
 			<Template>gaia/tree/bush_temperate</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="903.26587" z="334.79319"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="16314"/>
 		</Entity>
 		<Entity uid="262">
 			<Template>gaia/tree/bush_temperate</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="904.02485" z="334.99466"/>
 			<Orientation y="-0.05336"/>
 			<Actor seed="57400"/>
 		</Entity>
 		<Entity uid="263">
 			<Template>gaia/tree/bush_temperate</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="901.89972" z="342.23841"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="56192"/>
 		</Entity>
 		<Entity uid="264">
 			<Template>gaia/tree/bush_temperate</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="904.89258" z="337.63321"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="46788"/>
 		</Entity>
 		<Entity uid="265">
 			<Template>gaia/tree/bush_temperate</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="905.36982" z="336.30662"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="4994"/>
 		</Entity>
 		<Entity uid="266">
 			<Template>gaia/tree/bush_temperate</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="907.78834" z="333.67823"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="45056"/>
 		</Entity>
 		<Entity uid="267">
 			<Template>gaia/tree/bush_temperate</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="908.47492" z="332.68317"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="50996"/>
 		</Entity>
 		<Entity uid="268">
 			<Template>gaia/tree/bush_temperate</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="910.54145" z="326.65992"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="11508"/>
 		</Entity>
 		<Entity uid="269">
 			<Template>gaia/tree/bush_temperate</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="910.2765" z="324.32178"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="9608"/>
 		</Entity>
 		<Entity uid="270">
 			<Template>gaia/tree/bush_temperate</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="911.55561" z="320.52106"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="47790"/>
 		</Entity>
 		<Entity uid="271">
 			<Template>gaia/tree/bush_temperate</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="912.45588" z="319.54523"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="2414"/>
 		</Entity>
 		<Entity uid="272">
 			<Template>gaia/tree/bush_temperate</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="910.03821" z="323.8729"/>
 			<Orientation y="-0.62307"/>
 			<Actor seed="53756"/>
 		</Entity>
 		<Entity uid="273">
 			<Template>gaia/tree/bush_temperate</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="906.08698" z="332.40613"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="15300"/>
 		</Entity>
 		<Entity uid="274">
 			<Template>gaia/tree/bush_temperate</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="908.25525" z="328.44562"/>
 			<Orientation y="2.62064"/>
 			<Actor seed="36466"/>
 		</Entity>
 		<Entity uid="275">
 			<Template>gaia/tree/bush_temperate</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="910.33509" z="324.1035"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="55092"/>
 		</Entity>
 		<Entity uid="276">
 			<Template>gaia/tree/bush_temperate</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="907.17322" z="333.21833"/>
 			<Orientation y="-0.68316"/>
 			<Actor seed="59374"/>
 		</Entity>
 		<Entity uid="277">
 			<Template>gaia/tree/bush_temperate</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="905.36982" z="336.30662"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="27818"/>
 		</Entity>
 		<Entity uid="279">
 			<Template>gaia/tree/acacia</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="975.94538" z="326.9546"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="16874"/>
 		</Entity>
 		<Entity uid="280">
 			<Template>gaia/tree/acacia</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="1032.8108" z="346.7692"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="3442"/>
 		</Entity>
 		<Entity uid="281">
 			<Template>gaia/tree/acacia</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="991.2146" z="331.34046"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="39436"/>
 		</Entity>
 		<Entity uid="282">
 			<Template>gaia/tree/acacia</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="943.18519" z="337.73539"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="33672"/>
 		</Entity>
 		<Entity uid="283">
 			<Template>gaia/tree/acacia</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="933.81641" z="364.81974"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="33424"/>
 		</Entity>
 		<Entity uid="284">
 			<Template>gaia/tree/olive</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="1054.54395" z="395.30027"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="13316"/>
 		</Entity>
 		<Entity uid="285">
 			<Template>gaia/tree/olive</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="1054.27991" z="380.42692"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="41444"/>
 		</Entity>
 		<Entity uid="286">
 			<Template>gaia/tree/olive</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="1050.19654" z="365.7151"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="49428"/>
 		</Entity>
 		<Entity uid="287">
 			<Template>gaia/tree/olive</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="1066.49915" z="368.30454"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="29560"/>
 		</Entity>
 		<Entity uid="288">
 			<Template>gaia/tree/olive</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="1068.49573" z="379.07523"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="52560"/>
 		</Entity>
 		<Entity uid="289">
 			<Template>gaia/tree/olive</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="1069.52234" z="396.62693"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="4558"/>
 		</Entity>
 		<Entity uid="290">
 			<Template>gaia/tree/olive</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="1081.00293" z="371.0409"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="37354"/>
 		</Entity>
 		<Entity uid="291">
 			<Template>gaia/tree/olive</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="1082.41968" z="385.78541"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="49154"/>
 		</Entity>
 		<Entity uid="292">
 			<Template>gaia/tree/olive</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="1081.71875" z="402.41398"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="18508"/>
 		</Entity>
 		<Entity uid="293">
 			<Template>gaia/tree/olive</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="1039.91895" z="352.68232"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="40462"/>
 		</Entity>
 		<Entity uid="294">
 			<Template>gaia/tree/olive</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="1054.18311" z="347.90918"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="56780"/>
 		</Entity>
 		<Entity uid="295">
 			<Template>gaia/ore/mediterranean_small</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="1033.5918" z="327.37354"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="11814"/>
 		</Entity>
 		<Entity uid="296">
 			<Template>gaia/ore/mediterranean_large</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="988.88324" z="427.97394"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="23438"/>
 		</Entity>
 		<Entity uid="297">
 			<Template>gaia/rock/mediterranean_small</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="1001.41102" z="422.5387"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="57848"/>
 		</Entity>
 		<Entity uid="298">
 			<Template>gaia/rock/mediterranean_small</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="1026.19922" z="323.02784"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="10750"/>
 		</Entity>
 		<Entity uid="299">
 			<Template>gaia/rock/mediterranean_large</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="954.03888" z="321.7938"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="61418"/>
@@ -1850,7 +1850,7 @@
 		</Entity>
 		<Entity uid="307">
 			<Template>gaia/treasure/shipwreck</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="156.13929" z="454.12226"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="36122"/>
@@ -2897,77 +2897,77 @@
 		</Entity>
 		<Entity uid="538">
 			<Template>gaia/tree/bush_badlands</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="525.23584" z="383.74231"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="51944"/>
 		</Entity>
 		<Entity uid="539">
 			<Template>gaia/tree/bush_badlands</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="531.22657" z="378.28037"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="9218"/>
 		</Entity>
 		<Entity uid="540">
 			<Template>gaia/tree/bush_badlands</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="535.21955" z="373.8935"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="14394"/>
 		</Entity>
 		<Entity uid="541">
 			<Template>gaia/tree/bush_badlands</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="532.73328" z="374.4604"/>
 			<Orientation y="-1.07758"/>
 			<Actor seed="8166"/>
 		</Entity>
 		<Entity uid="542">
 			<Template>gaia/tree/bush_badlands</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="519.68659" z="381.56687"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="62270"/>
 		</Entity>
 		<Entity uid="543">
 			<Template>gaia/tree/bush_badlands</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="520.6269" z="382.37525"/>
 			<Orientation y="1.89095"/>
 			<Actor seed="29696"/>
 		</Entity>
 		<Entity uid="544">
 			<Template>gaia/tree/bush_badlands</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="525.42109" z="379.75974"/>
 			<Orientation y="2.44317"/>
 			<Actor seed="46018"/>
 		</Entity>
 		<Entity uid="545">
 			<Template>gaia/tree/bush_badlands</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="530.24927" z="374.87183"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="5962"/>
 		</Entity>
 		<Entity uid="546">
 			<Template>gaia/tree/bush_badlands</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="518.34809" z="421.78095"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="51612"/>
 		</Entity>
 		<Entity uid="547">
 			<Template>gaia/tree/bush_badlands</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="515.45636" z="404.51078"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="52170"/>
 		</Entity>
 		<Entity uid="548">
 			<Template>gaia/tree/bush_badlands</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="556.58808" z="357.83503"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="59966"/>
@@ -2981,14 +2981,14 @@
 		</Entity>
 		<Entity uid="550">
 			<Template>gaia/tree/bush_badlands</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="541.13672" z="367.7977"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="54492"/>
 		</Entity>
 		<Entity uid="551">
 			<Template>gaia/tree/bush_badlands</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="544.9065" z="363.79899"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="52586"/>
@@ -3009,7 +3009,7 @@
 		</Entity>
 		<Entity uid="554">
 			<Template>gaia/tree/bush_badlands</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="488.94312" z="395.5842"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="46460"/>
@@ -3066,28 +3066,28 @@
 		</Entity>
 		<Entity uid="562">
 			<Template>gaia/tree/bush_badlands</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="603.12043" z="354.08054"/>
 			<Orientation y="2.1467"/>
 			<Actor seed="46776"/>
 		</Entity>
 		<Entity uid="563">
 			<Template>gaia/tree/bush_badlands</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="586.7627" z="353.99408"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="13644"/>
 		</Entity>
 		<Entity uid="564">
 			<Template>gaia/tree/bush_badlands</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="521.23035" z="371.0947"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="42280"/>
 		</Entity>
 		<Entity uid="565">
 			<Template>gaia/tree/bush_badlands</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="628.30536" z="352.22236"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="39350"/>
@@ -3150,7 +3150,7 @@
 		</Entity>
 		<Entity uid="574">
 			<Template>gaia/tree/bush_badlands</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="722.15314" z="393.76352"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="5812"/>
@@ -4394,7 +4394,7 @@
 		</Entity>
 		<Entity uid="751">
 			<Template>gaia/tree/bush_badlands</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="1201.75367" z="453.19751"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="2834"/>
@@ -4422,7 +4422,7 @@
 		</Entity>
 		<Entity uid="755">
 			<Template>gaia/tree/bush_badlands</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="1218.94031" z="448.74421"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="45054"/>
@@ -4744,7 +4744,7 @@
 		</Entity>
 		<Entity uid="802">
 			<Template>gaia/tree/bush_badlands</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="763.21991" z="308.37229"/>
 			<Orientation y="-2.0354"/>
 			<Actor seed="17754"/>
@@ -5774,14 +5774,14 @@
 		</Entity>
 		<Entity uid="951">
 			<Template>gaia/tree/bush_badlands</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="1216.50379" z="446.09174"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="19864"/>
 		</Entity>
 		<Entity uid="952">
 			<Template>gaia/tree/bush_badlands</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="1214.04786" z="459.22767"/>
 			<Orientation y="-1.3135"/>
 			<Actor seed="59790"/>
@@ -5851,21 +5851,21 @@
 		</Entity>
 		<Entity uid="962">
 			<Template>gaia/tree/bush_badlands</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="1217.52002" z="447.12275"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="50314"/>
 		</Entity>
 		<Entity uid="963">
 			<Template>gaia/tree/bush_badlands</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="1221.34498" z="448.87757"/>
 			<Orientation y="3.06727"/>
 			<Actor seed="29138"/>
 		</Entity>
 		<Entity uid="964">
 			<Template>gaia/tree/bush_badlands</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="1220.839" z="428.8144"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="47026"/>
@@ -6341,35 +6341,35 @@
 		</Entity>
 		<Entity uid="1055">
 			<Template>gaia/ore/mediterranean_large</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="622.6175" z="457.49314"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="58028"/>
 		</Entity>
 		<Entity uid="1056">
 			<Template>gaia/rock/temperate_small</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="630.52491" z="448.01276"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="14652"/>
 		</Entity>
 		<Entity uid="1057">
 			<Template>gaia/rock/mediterranean_small</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="703.53705" z="448.54715"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="51074"/>
 		</Entity>
 		<Entity uid="1058">
 			<Template>gaia/rock/mediterranean_small</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="750.54822" z="441.35938"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="14176"/>
 		</Entity>
 		<Entity uid="1059">
 			<Template>gaia/rock/mediterranean_small</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="813.77747" z="416.95719"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="34814"/>
@@ -7762,49 +7762,49 @@
 		</Entity>
 		<Entity uid="1303">
 			<Template>gaia/rock/mediterranean_large</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="432.39426" z="347.54096"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="63668"/>
 		</Entity>
 		<Entity uid="1307">
 			<Template>gaia/rock/temperate_small</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="438.50416" z="355.24933"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="13632"/>
 		</Entity>
 		<Entity uid="1310">
 			<Template>gaia/rock/temperate_small</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="432.30973" z="346.8072"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="30710"/>
 		</Entity>
 		<Entity uid="1311">
 			<Template>gaia/rock/temperate_small</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="435.32343" z="343.82984"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="62202"/>
 		</Entity>
 		<Entity uid="1312">
 			<Template>gaia/rock/temperate_small</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="437.69297" z="345.51514"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="4676"/>
 		</Entity>
 		<Entity uid="1313">
 			<Template>gaia/rock/mediterranean_large</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="428.16974" z="343.50275"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="37334"/>
 		</Entity>
 		<Entity uid="1314">
 			<Template>gaia/rock/mediterranean_large</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="434.49424" z="618.0929"/>
 			<Orientation y="2.35621"/>
 			<Obstruction group="503"/>
@@ -7812,7 +7812,7 @@
 		</Entity>
 		<Entity uid="1315">
 			<Template>gaia/treasure/shipwreck_sail_boat_cut</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="425.56333" z="506.58945"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="23440"/>
@@ -8050,14 +8050,14 @@
 		</Entity>
 		<Entity uid="1367">
 			<Template>gaia/rock/temperate_large</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="993.97651" z="482.17975"/>
 			<Orientation y="2.42666"/>
 			<Actor seed="60286"/>
 		</Entity>
 		<Entity uid="1368">
 			<Template>gaia/rock/temperate_large</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="927.9853" z="445.192"/>
 			<Orientation y="2.35621"/>
 			<Obstruction group="59"/>
@@ -8065,70 +8065,70 @@
 		</Entity>
 		<Entity uid="1370">
 			<Template>gaia/tree/cypress</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="982.6615" z="489.02659"/>
 			<Orientation y="2.42666"/>
 			<Actor seed="32192"/>
 		</Entity>
 		<Entity uid="1371">
 			<Template>gaia/tree/cypress</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="982.95636" z="501.46875"/>
 			<Orientation y="2.42666"/>
 			<Actor seed="25976"/>
 		</Entity>
 		<Entity uid="1372">
 			<Template>gaia/tree/cypress</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="983.33021" z="515.93952"/>
 			<Orientation y="2.42666"/>
 			<Actor seed="31414"/>
 		</Entity>
 		<Entity uid="1373">
 			<Template>gaia/tree/cypress</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="983.55903" z="527.29651"/>
 			<Orientation y="2.42666"/>
 			<Actor seed="34094"/>
 		</Entity>
 		<Entity uid="1374">
 			<Template>gaia/tree/cypress</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="983.20038" z="540.03693"/>
 			<Orientation y="2.42666"/>
 			<Actor seed="63758"/>
 		</Entity>
 		<Entity uid="1375">
 			<Template>gaia/tree/cypress</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="880.87928" z="546.69098"/>
 			<Orientation y="2.45493"/>
 			<Actor seed="63758"/>
 		</Entity>
 		<Entity uid="1376">
 			<Template>gaia/tree/cypress</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="880.1117" z="533.90137"/>
 			<Orientation y="2.45493"/>
 			<Actor seed="34094"/>
 		</Entity>
 		<Entity uid="1377">
 			<Template>gaia/tree/cypress</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="879.2688" z="522.28162"/>
 			<Orientation y="2.45493"/>
 			<Actor seed="31414"/>
 		</Entity>
 		<Entity uid="1378">
 			<Template>gaia/tree/cypress</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="877.77533" z="508.98395"/>
 			<Orientation y="2.45493"/>
 			<Actor seed="25976"/>
 		</Entity>
 		<Entity uid="1379">
 			<Template>gaia/tree/cypress</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="877.12916" z="496.55512"/>
 			<Orientation y="2.45493"/>
 			<Actor seed="32192"/>
@@ -8875,7 +8875,7 @@
 		</Entity>
 		<Entity uid="1537">
 			<Template>gaia/tree/aleppo_pine</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="515.96058" z="566.2085"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="26368"/>
@@ -8903,105 +8903,105 @@
 		</Entity>
 		<Entity uid="1541">
 			<Template>gaia/fauna_rabbit</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="558.85969" z="564.4228"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="14826"/>
 		</Entity>
 		<Entity uid="1542">
 			<Template>gaia/fauna_rabbit</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="537.07996" z="516.97376"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="46840"/>
 		</Entity>
 		<Entity uid="1543">
 			<Template>gaia/fauna_rabbit</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="612.05304" z="638.96296"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="4876"/>
 		</Entity>
 		<Entity uid="1544">
 			<Template>gaia/fauna_rabbit</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="579.37244" z="689.78394"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="47466"/>
 		</Entity>
 		<Entity uid="1545">
 			<Template>gaia/fauna_rabbit</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="525.21973" z="623.72376"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="31074"/>
 		</Entity>
 		<Entity uid="1546">
 			<Template>gaia/fauna_rabbit</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="544.24598" z="723.32325"/>
 			<Orientation y="2.2805"/>
 			<Actor seed="63408"/>
 		</Entity>
 		<Entity uid="1547">
 			<Template>gaia/fauna_rabbit</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="597.72834" z="456.28595"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="15364"/>
 		</Entity>
 		<Entity uid="1548">
 			<Template>gaia/fauna_rabbit</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="574.3368" z="451.22959"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="50084"/>
 		</Entity>
 		<Entity uid="1549">
 			<Template>gaia/fauna_rabbit</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="633.06458" z="424.22181"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="63438"/>
 		</Entity>
 		<Entity uid="1550">
 			<Template>gaia/fauna_rabbit</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="649.97333" z="427.04413"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="8082"/>
 		</Entity>
 		<Entity uid="1551">
 			<Template>gaia/fauna_rabbit</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="654.63025" z="372.146"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="27490"/>
 		</Entity>
 		<Entity uid="1552">
 			<Template>gaia/fauna_rabbit</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="686.94105" z="363.79337"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="36616"/>
 		</Entity>
 		<Entity uid="1553">
 			<Template>gaia/fauna_rabbit</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="777.55152" z="406.27024"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="40368"/>
 		</Entity>
 		<Entity uid="1554">
 			<Template>gaia/fauna_rabbit</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="779.48841" z="391.5344"/>
 			<Orientation y="0.82634"/>
 			<Actor seed="55362"/>
 		</Entity>
 		<Entity uid="1555">
 			<Template>gaia/fauna_rabbit</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="819.16797" z="413.06226"/>
 			<Orientation y="-0.27439"/>
 			<Actor seed="64212"/>
@@ -9022,7 +9022,7 @@
 		</Entity>
 		<Entity uid="1558">
 			<Template>gaia/fauna_rabbit</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="857.90217" z="657.64197"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="17282"/>
@@ -9050,84 +9050,84 @@
 		</Entity>
 		<Entity uid="1562">
 			<Template>gaia/fauna_rabbit</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="1007.42554" z="705.41791"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="60442"/>
 		</Entity>
 		<Entity uid="1563">
 			<Template>gaia/fauna_rabbit</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="1060.9956" z="748.0842"/>
 			<Orientation y="2.67307"/>
 			<Actor seed="48730"/>
 		</Entity>
 		<Entity uid="1564">
 			<Template>gaia/fauna_rabbit</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="1091.0094" z="735.16846"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="34796"/>
 		</Entity>
 		<Entity uid="1565">
 			<Template>gaia/fauna_rabbit</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="1007.72632" z="807.68482"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="35610"/>
 		</Entity>
 		<Entity uid="1566">
 			<Template>gaia/fauna_rabbit</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="1052.60474" z="836.74268"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="32570"/>
 		</Entity>
 		<Entity uid="1567">
 			<Template>gaia/fauna_rabbit</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="958.9687" z="375.19654"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="53698"/>
 		</Entity>
 		<Entity uid="1568">
 			<Template>gaia/fauna_rabbit</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="970.65027" z="354.83045"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="21974"/>
 		</Entity>
 		<Entity uid="1569">
 			<Template>gaia/fauna_rabbit</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="947.91938" z="345.81455"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="48500"/>
 		</Entity>
 		<Entity uid="1570">
 			<Template>gaia/fauna_rabbit</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="1050.91749" z="397.50913"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="63082"/>
 		</Entity>
 		<Entity uid="1571">
 			<Template>gaia/fauna_rabbit</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="1041.40455" z="354.06821"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="39420"/>
 		</Entity>
 		<Entity uid="1572">
 			<Template>gaia/fauna_rabbit</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="1013.2765" z="332.95282"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="27208"/>
 		</Entity>
 		<Entity uid="1573">
 			<Template>gaia/fauna_rabbit</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="1267.61646" z="743.7323"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="21834"/>
@@ -9162,7 +9162,7 @@
 		</Entity>
 		<Entity uid="1578">
 			<Template>gaia/fauna_rabbit</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="1459.05896" z="577.41456"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="50096"/>
@@ -9231,7 +9231,7 @@
 		</Entity>
 		<Entity uid="1588">
 			<Template>gaia/fauna_rabbit</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="1401.38904" z="964.0113"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="40218"/>
@@ -9348,35 +9348,35 @@
 		</Entity>
 		<Entity uid="1606">
 			<Template>gaia/fauna_rabbit</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="1458.22608" z="567.8039"/>
 			<Orientation y="2.4215"/>
 			<Actor seed="63066"/>
 		</Entity>
 		<Entity uid="1607">
 			<Template>gaia/fauna_rabbit</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="1466.93702" z="552.70124"/>
 			<Orientation y="-2.78696"/>
 			<Actor seed="56264"/>
 		</Entity>
 		<Entity uid="1608">
 			<Template>gaia/fauna_rabbit</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="1443.73084" z="511.84247"/>
 			<Orientation y="-1.18133"/>
 			<Actor seed="60622"/>
 		</Entity>
 		<Entity uid="1609">
 			<Template>gaia/fauna_rabbit</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="1430.08501" z="534.0263"/>
 			<Orientation y="2.91875"/>
 			<Actor seed="53174"/>
 		</Entity>
 		<Entity uid="1610">
 			<Template>gaia/fauna_rabbit</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="1422.82898" z="563.36158"/>
 			<Orientation y="-0.6841"/>
 			<Actor seed="22384"/>
@@ -9397,56 +9397,56 @@
 		</Entity>
 		<Entity uid="1613">
 			<Template>gaia/fauna_rabbit</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="1345.92261" z="606.42652"/>
 			<Orientation y="2.19524"/>
 			<Actor seed="36724"/>
 		</Entity>
 		<Entity uid="1614">
 			<Template>gaia/fauna_rabbit</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="1397.6537" z="566.75666"/>
 			<Orientation y="2.79426"/>
 			<Actor seed="47184"/>
 		</Entity>
 		<Entity uid="1615">
 			<Template>gaia/fauna_rabbit</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="1410.0348" z="527.45038"/>
 			<Orientation y="2.87197"/>
 			<Actor seed="59732"/>
 		</Entity>
 		<Entity uid="1616">
 			<Template>gaia/fauna_rabbit</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="1411.41245" z="507.06261"/>
 			<Orientation y="-2.79545"/>
 			<Actor seed="1770"/>
 		</Entity>
 		<Entity uid="1617">
 			<Template>gaia/fauna_rabbit</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="1436.86731" z="487.65491"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="550"/>
 		</Entity>
 		<Entity uid="1618">
 			<Template>gaia/fauna_rabbit</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="1453.42701" z="492.4397"/>
 			<Orientation y="0.27321"/>
 			<Actor seed="25300"/>
 		</Entity>
 		<Entity uid="1619">
 			<Template>gaia/fauna_rabbit</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="1467.27344" z="530.30463"/>
 			<Orientation y="0.32308"/>
 			<Actor seed="56968"/>
 		</Entity>
 		<Entity uid="1620">
 			<Template>gaia/fauna_rabbit</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="1510.91883" z="671.88245"/>
 			<Orientation y="-0.02176"/>
 			<Actor seed="21386"/>
@@ -9488,28 +9488,28 @@
 		</Entity>
 		<Entity uid="1626">
 			<Template>gaia/fauna_rabbit</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="1222.41651" z="850.31202"/>
 			<Orientation y="-1.93212"/>
 			<Actor seed="21962"/>
 		</Entity>
 		<Entity uid="1627">
 			<Template>gaia/fauna_rabbit</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="1113.52234" z="862.74317"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="10592"/>
 		</Entity>
 		<Entity uid="1628">
 			<Template>gaia/fauna_rabbit</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="1148.88123" z="809.4878"/>
 			<Orientation y="2.4034"/>
 			<Actor seed="29916"/>
 		</Entity>
 		<Entity uid="1629">
 			<Template>gaia/fauna_rabbit</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="1199.17286" z="744.41663"/>
 			<Orientation y="2.68371"/>
 			<Actor seed="51080"/>
@@ -9537,7 +9537,7 @@
 		</Entity>
 		<Entity uid="1633">
 			<Template>gaia/fauna_rabbit</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="1340.98755" z="588.80555"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="56448"/>
@@ -9719,14 +9719,14 @@
 		</Entity>
 		<Entity uid="1660">
 			<Template>gaia/tree/aleppo_pine</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="546.04957" z="518.94574"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="51912"/>
 		</Entity>
 		<Entity uid="1661">
 			<Template>gaia/tree/aleppo_pine</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="502.00058" z="509.80329"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="46632"/>
@@ -10069,7 +10069,7 @@
 		</Entity>
 		<Entity uid="1721">
 			<Template>gaia/tree/oak_new</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="738.80146" z="515.55152"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="54840"/>
@@ -10328,14 +10328,14 @@
 		</Entity>
 		<Entity uid="1783">
 			<Template>gaia/treasure/metal_persian_big</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="691.39631" z="552.42493"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="37084"/>
 		</Entity>
 		<Entity uid="1784">
 			<Template>gaia/treasure/metal_persian_small</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="664.60071" z="544.43592"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="53808"/>
@@ -10769,7 +10769,7 @@
 		</Entity>
 		<Entity uid="1854">
 			<Template>gaia/tree/oak</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="1074.16382" z="685.73798"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="4730"/>
@@ -10853,7 +10853,7 @@
 		</Entity>
 		<Entity uid="1866">
 			<Template>gaia/tree/oak_large</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="940.21753" z="642.63794"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="26766"/>
@@ -11070,14 +11070,14 @@
 		</Entity>
 		<Entity uid="1898">
 			<Template>gaia/ore/greece_small</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="473.53052" z="508.63016"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="44770"/>
 		</Entity>
 		<Entity uid="1899">
 			<Template>gaia/ore/tropical_large</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="1062.26563" z="809.58655"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="6056"/>
@@ -11665,7 +11665,7 @@
 		</Entity>
 		<Entity uid="2004">
 			<Template>gaia/fauna_rabbit</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="498.25959" z="671.60932"/>
 			<Orientation y="2.2296"/>
 			<Actor seed="63408"/>
@@ -11686,14 +11686,14 @@
 		</Entity>
 		<Entity uid="2007">
 			<Template>gaia/treasure/golden_fleece</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="546.24274" z="634.44336"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="58444"/>
 		</Entity>
 		<Entity uid="2008">
 			<Template>gaia/treasure/golden_fleece</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="568.73945" z="660.42341"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="28316"/>
@@ -15970,7 +15970,7 @@
 		</Entity>
 		<Entity uid="2689">
 			<Template>gaia/tree/bush_badlands</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="1266.31751" z="733.65564"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="61730"/>

--- a/maps/scenarios/raiders_in_the_alps.xml
+++ b/maps/scenarios/raiders_in_the_alps.xml
@@ -15045,7 +15045,7 @@
 		</Entity>
 		<Entity uid="2492">
 			<Template>gaia/tree/oak_large</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="168.18702" z="408.11442"/>
 			<Orientation y="7.52323"/>
 			<Actor seed="35781"/>
@@ -16858,98 +16858,98 @@
 		</Entity>
 		<Entity uid="2861">
 			<Template>gaia/treasure/food_barrels_buried</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="256.51316" z="758.46479"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="10875"/>
 		</Entity>
 		<Entity uid="2862">
 			<Template>gaia/treasure/food_crate</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="260.33173" z="764.3407"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="31188"/>
 		</Entity>
 		<Entity uid="2864">
 			<Template>gaia/treasure/wood</Template>
-			<Player>3</Player>
+			<Player>0</Player>
 			<Position x="578.83436" z="150.48462"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="25160"/>
 		</Entity>
 		<Entity uid="2865">
 			<Template>gaia/treasure/food_barrel</Template>
-			<Player>3</Player>
+			<Player>0</Player>
 			<Position x="582.46052" z="152.08942"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="19735"/>
 		</Entity>
 		<Entity uid="2866">
 			<Template>gaia/fauna_horse</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="128.96753" z="503.9632"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="12570"/>
 		</Entity>
 		<Entity uid="2867">
 			<Template>gaia/fauna_horse</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="136.36377" z="500.69233"/>
 			<Orientation y="0.24372"/>
 			<Actor seed="58764"/>
 		</Entity>
 		<Entity uid="2868">
 			<Template>gaia/fauna_horse</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="119.53507" z="508.93668"/>
 			<Orientation y="-1.3577"/>
 			<Actor seed="52512"/>
 		</Entity>
 		<Entity uid="2869">
 			<Template>gaia/fauna_horse</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="115.479" z="503.04145"/>
 			<Orientation y="-3.03649"/>
 			<Actor seed="3188"/>
 		</Entity>
 		<Entity uid="2870">
 			<Template>gaia/fauna_horse</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="132.72992" z="515.38636"/>
 			<Orientation y="0.13474"/>
 			<Actor seed="32927"/>
 		</Entity>
 		<Entity uid="2871">
 			<Template>gaia/fauna_chicken</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="190.77216" z="431.98047"/>
 			<Orientation y="-2.96361"/>
 			<Actor seed="61649"/>
 		</Entity>
 		<Entity uid="2872">
 			<Template>gaia/fauna_chicken</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="192.80887" z="431.04731"/>
 			<Orientation y="0.49128"/>
 			<Actor seed="30594"/>
 		</Entity>
 		<Entity uid="2873">
 			<Template>gaia/fauna_chicken</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="195.58127" z="431.77012"/>
 			<Orientation y="-1.62443"/>
 			<Actor seed="9847"/>
 		</Entity>
 		<Entity uid="2874">
 			<Template>gaia/fauna_chicken</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="195.65186" z="429.59656"/>
 			<Orientation y="-3.11579"/>
 			<Actor seed="57306"/>
 		</Entity>
 		<Entity uid="2875">
 			<Template>gaia/fauna_chicken</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="194.38804" z="433.75602"/>
 			<Orientation y="-0.9819"/>
 			<Actor seed="18710"/>

--- a/maps/scenarios/siege_of_greece.xml
+++ b/maps/scenarios/siege_of_greece.xml
@@ -6326,84 +6326,84 @@
 		</Entity>
 		<Entity uid="1241">
 			<Template>gaia/tree/bush_temperate</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="1056.39295" z="1115.08948"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="14496"/>
 		</Entity>
 		<Entity uid="1278">
 			<Template>gaia/tree/bush_temperate</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="1071.27503" z="1102.06507"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="55256"/>
 		</Entity>
 		<Entity uid="1283">
 			<Template>gaia/tree/bush_temperate</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="1070.04444" z="1103.60169"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="59116"/>
 		</Entity>
 		<Entity uid="1664">
 			<Template>gaia/rock/mediterranean_small</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="756.27021" z="820.59919"/>
 			<Orientation y="-1.90314"/>
 			<Actor seed="6692"/>
 		</Entity>
 		<Entity uid="1665">
 			<Template>gaia/rock/mediterranean_small</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="747.12623" z="819.91706"/>
 			<Orientation y="-2.35785"/>
 			<Actor seed="51728"/>
 		</Entity>
 		<Entity uid="1666">
 			<Template>gaia/rock/mediterranean_small</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="737.64515" z="822.2256"/>
 			<Orientation y="3.03843"/>
 			<Actor seed="37750"/>
 		</Entity>
 		<Entity uid="1667">
 			<Template>gaia/rock/mediterranean_small</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="749.88178" z="823.16578"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="49366"/>
 		</Entity>
 		<Entity uid="1668">
 			<Template>gaia/rock/mediterranean_small</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="741.69459" z="817.26172"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="42976"/>
 		</Entity>
 		<Entity uid="1669">
 			<Template>gaia/rock/mediterranean_small</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="964.86219" z="1065.79517"/>
 			<Orientation y="-2.13447"/>
 			<Actor seed="418"/>
 		</Entity>
 		<Entity uid="1670">
 			<Template>gaia/rock/mediterranean_small</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="962.39509" z="1070.0973"/>
 			<Orientation y="-1.2051"/>
 			<Actor seed="12964"/>
 		</Entity>
 		<Entity uid="1672">
 			<Template>gaia/rock/mediterranean_small</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="1102.33143" z="1049.02967"/>
 			<Orientation y="-1.86913"/>
 			<Actor seed="33764"/>
 		</Entity>
 		<Entity uid="1673">
 			<Template>gaia/rock/mediterranean_small</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="1104.31617" z="1044.53907"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="42128"/>
@@ -22115,427 +22115,427 @@
 		</Entity>
 		<Entity uid="5163">
 			<Template>gaia/treasure/food_barrel</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="989.0782" z="755.9162"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="4296"/>
 		</Entity>
 		<Entity uid="5164">
 			<Template>gaia/treasure/food_barrel</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="987.667" z="755.65503"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="35886"/>
 		</Entity>
 		<Entity uid="5165">
 			<Template>gaia/treasure/food_barrel</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="988.61768" z="754.51893"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="27958"/>
 		</Entity>
 		<Entity uid="5166">
 			<Template>gaia/treasure/food_barrel</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="984.42713" z="767.41266"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="26562"/>
 		</Entity>
 		<Entity uid="5167">
 			<Template>gaia/treasure/food_barrel</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="984.16236" z="768.80799"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="22800"/>
 		</Entity>
 		<Entity uid="5168">
 			<Template>gaia/treasure/food_barrel</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="983.15326" z="767.55781"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="13490"/>
 		</Entity>
 		<Entity uid="5169">
 			<Template>gaia/treasure/food_bin</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="994.16639" z="781.54133"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="56508"/>
 		</Entity>
 		<Entity uid="5170">
 			<Template>gaia/treasure/food_bin</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="993.0597" z="780.45917"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="1636"/>
 		</Entity>
 		<Entity uid="5171">
 			<Template>gaia/treasure/food_bin</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="995.48963" z="782.61384"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="22130"/>
 		</Entity>
 		<Entity uid="5172">
 			<Template>gaia/treasure/food_persian_small</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="986.95734" z="775.25464"/>
 			<Orientation y="-0.89271"/>
 			<Actor seed="17182"/>
 		</Entity>
 		<Entity uid="5173">
 			<Template>gaia/treasure/food_persian_small</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="1000.02631" z="780.65967"/>
 			<Orientation y="-0.32189"/>
 			<Actor seed="38404"/>
 		</Entity>
 		<Entity uid="5174">
 			<Template>gaia/treasure/food_persian_small</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="1007.33863" z="774.19361"/>
 			<Orientation y="-0.16037"/>
 			<Actor seed="13770"/>
 		</Entity>
 		<Entity uid="5175">
 			<Template>gaia/treasure/food_persian_big</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="1008.42615" z="763.11683"/>
 			<Orientation y="0.33643"/>
 			<Actor seed="48250"/>
 		</Entity>
 		<Entity uid="5176">
 			<Template>gaia/treasure/food_persian_big</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="998.90864" z="738.89399"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="19416"/>
 		</Entity>
 		<Entity uid="5177">
 			<Template>gaia/treasure/food_persian_big</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="990.25062" z="740.87964"/>
 			<Orientation y="-2.77451"/>
 			<Actor seed="36124"/>
 		</Entity>
 		<Entity uid="5178">
 			<Template>gaia/treasure/food_persian_small</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="989.64576" z="746.28956"/>
 			<Orientation y="-1.12087"/>
 			<Actor seed="50276"/>
 		</Entity>
 		<Entity uid="5179">
 			<Template>gaia/treasure/metal_persian_small</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="991.57935" z="736.62281"/>
 			<Orientation y="-3.02376"/>
 			<Actor seed="5356"/>
 		</Entity>
 		<Entity uid="5180">
 			<Template>gaia/treasure/metal_persian_small</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="1009.37238" z="794.85499"/>
 			<Orientation y="-2.27666"/>
 			<Actor seed="12416"/>
 		</Entity>
 		<Entity uid="5181">
 			<Template>gaia/treasure/metal_persian_big</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="1004.62513" z="794.60712"/>
 			<Orientation y="-3.1124"/>
 			<Actor seed="61780"/>
 		</Entity>
 		<Entity uid="5182">
 			<Template>gaia/treasure/metal_persian_big</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="1016.53736" z="767.51771"/>
 			<Orientation y="0.02604"/>
 			<Actor seed="6294"/>
 		</Entity>
 		<Entity uid="5183">
 			<Template>gaia/treasure/metal_persian_big</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="1012.65076" z="751.96753"/>
 			<Orientation y="-1.51432"/>
 			<Actor seed="57564"/>
 		</Entity>
 		<Entity uid="5184">
 			<Template>gaia/treasure/pegasus</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="1028.10108" z="793.00092"/>
 			<Orientation y="1.83683"/>
 			<Actor seed="23086"/>
 		</Entity>
 		<Entity uid="5186">
 			<Template>gaia/treasure/pegasus</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="1066.66395" z="878.24738"/>
 			<Orientation y="-0.02878"/>
 			<Actor seed="58578"/>
 		</Entity>
 		<Entity uid="5187">
 			<Template>gaia/treasure/wood</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="1147.88025" z="755.64783"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="30386"/>
 		</Entity>
 		<Entity uid="5188">
 			<Template>gaia/treasure/wood</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="1151.90088" z="756.70417"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="12880"/>
 		</Entity>
 		<Entity uid="5189">
 			<Template>gaia/treasure/wood</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="1155.47767" z="755.59742"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="46896"/>
 		</Entity>
 		<Entity uid="5190">
 			<Template>gaia/treasure/wood</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="1158.29542" z="755.44776"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="35010"/>
 		</Entity>
 		<Entity uid="5191">
 			<Template>gaia/treasure/wood</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="1160.99695" z="755.6844"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="56664"/>
 		</Entity>
 		<Entity uid="5192">
 			<Template>gaia/treasure/wood</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="1163.08741" z="755.81592"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="17932"/>
 		</Entity>
 		<Entity uid="5193">
 			<Template>gaia/treasure/wood</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="1164.10511" z="756.02076"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="4456"/>
 		</Entity>
 		<Entity uid="5194">
 			<Template>gaia/treasure/wood</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="1165.8296" z="756.27466"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="29780"/>
 		</Entity>
 		<Entity uid="5195">
 			<Template>gaia/treasure/wood</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="1168.69678" z="756.24207"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="64628"/>
 		</Entity>
 		<Entity uid="5196">
 			<Template>gaia/treasure/wood</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="1171.20752" z="756.1031"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="53700"/>
 		</Entity>
 		<Entity uid="5197">
 			<Template>gaia/treasure/wood</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="1173.96753" z="755.81635"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="1948"/>
 		</Entity>
 		<Entity uid="5198">
 			<Template>gaia/treasure/wood</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="1145.58716" z="755.40772"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="51224"/>
 		</Entity>
 		<Entity uid="5199">
 			<Template>gaia/treasure/wood</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="1142.96082" z="756.19001"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="22136"/>
 		</Entity>
 		<Entity uid="5200">
 			<Template>gaia/treasure/wood</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="1140.38794" z="756.02137"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="55868"/>
 		</Entity>
 		<Entity uid="5201">
 			<Template>gaia/treasure/wood</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="1139.1565" z="755.56281"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="26408"/>
 		</Entity>
 		<Entity uid="5202">
 			<Template>gaia/treasure/wood</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="1137.14673" z="755.13221"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="2342"/>
 		</Entity>
 		<Entity uid="5203">
 			<Template>gaia/treasure/wood</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="1176.48731" z="756.13324"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="5318"/>
 		</Entity>
 		<Entity uid="5204">
 			<Template>gaia/treasure/food_persian_small</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="1098.29346" z="713.3805"/>
 			<Orientation y="0.23519"/>
 			<Actor seed="8096"/>
 		</Entity>
 		<Entity uid="5207">
 			<Template>gaia/treasure/food_jars</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="1125.6554" z="712.41645"/>
 			<Orientation y="0.01371"/>
 			<Actor seed="13432"/>
 		</Entity>
 		<Entity uid="5208">
 			<Template>gaia/treasure/food_jars</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="1129.61536" z="694.7823"/>
 			<Orientation y="-0.38781"/>
 			<Actor seed="41962"/>
 		</Entity>
 		<Entity uid="5209">
 			<Template>gaia/treasure/food_jars</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="1122.48047" z="712.24299"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="33948"/>
 		</Entity>
 		<Entity uid="5210">
 			<Template>gaia/treasure/golden_fleece</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="1121.72144" z="714.11463"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="12088"/>
 		</Entity>
 		<Entity uid="5211">
 			<Template>gaia/treasure/golden_fleece</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="1117.9463" z="712.31135"/>
 			<Orientation y="1.32903"/>
 			<Actor seed="41302"/>
 		</Entity>
 		<Entity uid="5212">
 			<Template>gaia/treasure/golden_fleece</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="1128.97461" z="711.32923"/>
 			<Orientation y="-1.06557"/>
 			<Actor seed="8144"/>
 		</Entity>
 		<Entity uid="5213">
 			<Template>gaia/treasure/golden_fleece</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="1126.63868" z="715.14338"/>
 			<Orientation y="-2.78422"/>
 			<Actor seed="44874"/>
 		</Entity>
 		<Entity uid="5214">
 			<Template>gaia/treasure/golden_fleece</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="1123.95423" z="714.64588"/>
 			<Orientation y="2.89478"/>
 			<Actor seed="50182"/>
 		</Entity>
 		<Entity uid="5215">
 			<Template>gaia/treasure/golden_fleece</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="1131.72217" z="697.22748"/>
 			<Orientation y="-1.6025"/>
 			<Actor seed="4276"/>
 		</Entity>
 		<Entity uid="5216">
 			<Template>gaia/treasure/golden_fleece</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="1132.46998" z="693.91114"/>
 			<Orientation y="-1.16874"/>
 			<Actor seed="36062"/>
 		</Entity>
 		<Entity uid="5217">
 			<Template>gaia/treasure/golden_fleece</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="1132.86341" z="695.58045"/>
 			<Orientation y="-1.50605"/>
 			<Actor seed="26908"/>
 		</Entity>
 		<Entity uid="5218">
 			<Template>gaia/treasure/golden_fleece</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="1130.99" z="691.97693"/>
 			<Orientation y="-0.14158"/>
 			<Actor seed="64524"/>
 		</Entity>
 		<Entity uid="5219">
 			<Template>gaia/treasure/metal_persian_small</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="991.80927" z="704.82264"/>
 			<Orientation y="0.86959"/>
 			<Actor seed="44432"/>
 		</Entity>
 		<Entity uid="5220">
 			<Template>gaia/treasure/food_barrel</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="991.81592" z="712.38062"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="12654"/>
 		</Entity>
 		<Entity uid="5221">
 			<Template>gaia/treasure/food_barrel</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="990.81354" z="714.09473"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="39068"/>
 		</Entity>
 		<Entity uid="5222">
 			<Template>gaia/treasure/food_barrel</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="992.03095" z="713.60279"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="14628"/>
 		</Entity>
 		<Entity uid="5223">
 			<Template>gaia/treasure/food_barrel</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="991.11927" z="708.64216"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="64318"/>
 		</Entity>
 		<Entity uid="5224">
 			<Template>gaia/treasure/food_barrel</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="991.9864" z="707.54474"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="55358"/>
 		</Entity>
 		<Entity uid="5225">
 			<Template>gaia/treasure/food_barrel</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="993.02729" z="709.07447"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="11310"/>
 		</Entity>
 		<Entity uid="5226">
 			<Template>gaia/treasure/food_barrel</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="946.83704" z="717.78992"/>
 			<Orientation y="2.35621"/>
 			<Obstruction group="178"/>
@@ -22543,7 +22543,7 @@
 		</Entity>
 		<Entity uid="5227">
 			<Template>gaia/treasure/food_barrel</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="947.72651" z="717.74915"/>
 			<Orientation y="2.35621"/>
 			<Obstruction group="178"/>
@@ -22551,49 +22551,49 @@
 		</Entity>
 		<Entity uid="5228">
 			<Template>gaia/treasure/food_barrel</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="946.03235" z="718.925"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="30392"/>
 		</Entity>
 		<Entity uid="5229">
 			<Template>gaia/treasure/food_barrel</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="947.46174" z="719.44092"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="60144"/>
 		</Entity>
 		<Entity uid="5230">
 			<Template>gaia/treasure/food_barrel</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="945.95649" z="720.91468"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="14478"/>
 		</Entity>
 		<Entity uid="5231">
 			<Template>gaia/treasure/food_barrel</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="946.84168" z="720.72327"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="716"/>
 		</Entity>
 		<Entity uid="5232">
 			<Template>gaia/treasure/food_barrel</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="945.62073" z="721.99354"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="62766"/>
 		</Entity>
 		<Entity uid="5233">
 			<Template>gaia/treasure/food_barrel</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="947.22883" z="722.06403"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="27542"/>
 		</Entity>
 		<Entity uid="5234">
 			<Template>gaia/treasure/food_barrel</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="949.46961" z="717.7179"/>
 			<Orientation y="2.35621"/>
 			<Obstruction group="178"/>
@@ -22601,56 +22601,56 @@
 		</Entity>
 		<Entity uid="5235">
 			<Template>gaia/treasure/food_barrel</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="948.29657" z="748.24555"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="21106"/>
 		</Entity>
 		<Entity uid="5236">
 			<Template>gaia/treasure/food_barrel</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="947.65705" z="746.8603"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="15678"/>
 		</Entity>
 		<Entity uid="5237">
 			<Template>gaia/treasure/food_barrel</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="949.70148" z="746.34577"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="8926"/>
 		</Entity>
 		<Entity uid="5238">
 			<Template>gaia/treasure/food_barrel</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="946.89722" z="748.65192"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="27472"/>
 		</Entity>
 		<Entity uid="5239">
 			<Template>gaia/treasure/food_barrel</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="946.75678" z="746.22913"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="25564"/>
 		</Entity>
 		<Entity uid="5240">
 			<Template>gaia/treasure/food_barrel</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="949.98975" z="748.59894"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="19198"/>
 		</Entity>
 		<Entity uid="5241">
 			<Template>gaia/treasure/food_barrel</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="950.30152" z="747.62928"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="53282"/>
 		</Entity>
 		<Entity uid="5242">
 			<Template>gaia/treasure/food_barrel</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="948.19422" z="745.77564"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="2668"/>
@@ -22713,273 +22713,273 @@
 		</Entity>
 		<Entity uid="5251">
 			<Template>gaia/treasure/food_barrel</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="915.81843" z="853.04853"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="49446"/>
 		</Entity>
 		<Entity uid="5252">
 			<Template>gaia/treasure/food_barrel</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="917.08399" z="852.47498"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="38414"/>
 		</Entity>
 		<Entity uid="5253">
 			<Template>gaia/treasure/food_barrel</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="916.29029" z="851.9303"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="50402"/>
 		</Entity>
 		<Entity uid="5254">
 			<Template>gaia/treasure/food_barrel</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="936.83082" z="841.78296"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="44578"/>
 		</Entity>
 		<Entity uid="5255">
 			<Template>gaia/treasure/food_barrel</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="935.36585" z="841.89411"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="38416"/>
 		</Entity>
 		<Entity uid="5256">
 			<Template>gaia/treasure/food_barrel</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="933.70765" z="841.69922"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="25760"/>
 		</Entity>
 		<Entity uid="5257">
 			<Template>gaia/treasure/food_barrel</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="936.8661" z="821.93268"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="37318"/>
 		</Entity>
 		<Entity uid="5258">
 			<Template>gaia/treasure/food_barrel</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="936.98322" z="823.01368"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="15416"/>
 		</Entity>
 		<Entity uid="5259">
 			<Template>gaia/treasure/food_barrel</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="936.76294" z="824.72883"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="12816"/>
 		</Entity>
 		<Entity uid="5260">
 			<Template>gaia/treasure/food_barrel</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="935.52967" z="823.76221"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="20570"/>
 		</Entity>
 		<Entity uid="5261">
 			<Template>gaia/treasure/metal</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="910.72681" z="814.88788"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="29750"/>
 		</Entity>
 		<Entity uid="5262">
 			<Template>gaia/treasure/metal</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="911.09797" z="816.46015"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="63274"/>
 		</Entity>
 		<Entity uid="5263">
 			<Template>gaia/treasure/metal</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="910.0376" z="815.65595"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="5196"/>
 		</Entity>
 		<Entity uid="5264">
 			<Template>gaia/treasure/metal</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="915.06397" z="821.02814"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="17106"/>
 		</Entity>
 		<Entity uid="5265">
 			<Template>gaia/treasure/metal</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="916.77637" z="820.72046"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="15840"/>
 		</Entity>
 		<Entity uid="5266">
 			<Template>gaia/treasure/metal</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="916.39911" z="821.77112"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="61364"/>
 		</Entity>
 		<Entity uid="5267">
 			<Template>gaia/treasure/metal</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="922.73951" z="825.45295"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="52376"/>
 		</Entity>
 		<Entity uid="5268">
 			<Template>gaia/treasure/metal</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="920.71521" z="825.53315"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="19622"/>
 		</Entity>
 		<Entity uid="5269">
 			<Template>gaia/treasure/metal</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="922.05121" z="824.5954"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="16048"/>
 		</Entity>
 		<Entity uid="5270">
 			<Template>gaia/treasure/metal</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="919.66858" z="845.67212"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="28376"/>
 		</Entity>
 		<Entity uid="5271">
 			<Template>gaia/treasure/metal</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="918.2215" z="845.44288"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="13536"/>
 		</Entity>
 		<Entity uid="5272">
 			<Template>gaia/treasure/metal</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="918.63678" z="844.52051"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="9004"/>
 		</Entity>
 		<Entity uid="5273">
 			<Template>gaia/treasure/wood</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="912.7002" z="849.94617"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="23458"/>
 		</Entity>
 		<Entity uid="5274">
 			<Template>gaia/treasure/wood</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="909.18348" z="848.0553"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="59176"/>
 		</Entity>
 		<Entity uid="5275">
 			<Template>gaia/treasure/wood</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="904.41346" z="849.16724"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="35574"/>
 		</Entity>
 		<Entity uid="5276">
 			<Template>gaia/treasure/wood</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="906.9037" z="852.4256"/>
 			<Orientation y="1.39113"/>
 			<Actor seed="57032"/>
 		</Entity>
 		<Entity uid="5277">
 			<Template>gaia/treasure/wood</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="920.8827" z="823.75178"/>
 			<Orientation y="-1.44484"/>
 			<Actor seed="28286"/>
 		</Entity>
 		<Entity uid="5278">
 			<Template>gaia/treasure/wood</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="918.22681" z="823.17505"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="49982"/>
 		</Entity>
 		<Entity uid="5279">
 			<Template>gaia/treasure/wood</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="789.91749" z="1170.52283"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="10570"/>
 		</Entity>
 		<Entity uid="5280">
 			<Template>gaia/treasure/stone</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="809.93262" z="1173.21192"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="7158"/>
 		</Entity>
 		<Entity uid="5281">
 			<Template>gaia/treasure/stone</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="807.91987" z="1171.0127"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="25142"/>
 		</Entity>
 		<Entity uid="5282">
 			<Template>gaia/treasure/stone</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="805.68512" z="1174.16822"/>
 			<Orientation y="2.82258"/>
 			<Actor seed="53728"/>
 		</Entity>
 		<Entity uid="5283">
 			<Template>gaia/treasure/stone</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="807.18268" z="1167.59424"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="7434"/>
 		</Entity>
 		<Entity uid="5284">
 			<Template>gaia/treasure/stone</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="805.45881" z="1169.96253"/>
 			<Orientation y="2.98221"/>
 			<Actor seed="51448"/>
 		</Entity>
 		<Entity uid="5285">
 			<Template>gaia/treasure/stone</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="819.97492" z="1143.94007"/>
 			<Orientation y="-0.6744"/>
 			<Actor seed="35138"/>
 		</Entity>
 		<Entity uid="5286">
 			<Template>gaia/treasure/stone</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="819.16346" z="1146.438"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="14094"/>
 		</Entity>
 		<Entity uid="5287">
 			<Template>gaia/treasure/stone</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="816.1435" z="1145.05213"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="12552"/>
 		</Entity>
 		<Entity uid="5288">
 			<Template>gaia/treasure/stone</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="816.55201" z="1142.4679"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="19172"/>
 		</Entity>
 		<Entity uid="5289">
 			<Template>gaia/treasure/stone</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="815.34357" z="1140.72461"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="12356"/>
@@ -60973,112 +60973,112 @@
 		</Entity>
 		<Entity uid="13500">
 			<Template>gaia/rock/mediterranean_large</Template>
-			<Player>3</Player>
+			<Player>0</Player>
 			<Position x="313.84339" z="278.66108"/>
 			<Orientation y="-1.84572"/>
 			<Actor seed="15902"/>
 		</Entity>
 		<Entity uid="13501">
 			<Template>gaia/ore/mediterranean_large</Template>
-			<Player>3</Player>
+			<Player>0</Player>
 			<Position x="255.76645" z="256.5702"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="15058"/>
 		</Entity>
 		<Entity uid="13502">
 			<Template>gaia/ore/mediterranean_large</Template>
-			<Player>3</Player>
+			<Player>0</Player>
 			<Position x="146.9021" z="892.60029"/>
 			<Orientation y="1.38808"/>
 			<Actor seed="14932"/>
 		</Entity>
 		<Entity uid="13503">
 			<Template>gaia/rock/mediterranean_large</Template>
-			<Player>3</Player>
+			<Player>0</Player>
 			<Position x="221.81797" z="917.92695"/>
 			<Orientation y="-3.07171"/>
 			<Actor seed="39958"/>
 		</Entity>
 		<Entity uid="13504">
 			<Template>gaia/rock/mediterranean_large</Template>
-			<Player>3</Player>
+			<Player>0</Player>
 			<Position x="131.18888" z="783.62037"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="10300"/>
 		</Entity>
 		<Entity uid="13505">
 			<Template>gaia/rock/mediterranean_large</Template>
-			<Player>3</Player>
+			<Player>0</Player>
 			<Position x="117.9775" z="604.10383"/>
 			<Orientation y="0.89222"/>
 			<Actor seed="27528"/>
 		</Entity>
 		<Entity uid="13506">
 			<Template>gaia/rock/mediterranean_large</Template>
-			<Player>3</Player>
+			<Player>0</Player>
 			<Position x="233.18738" z="505.52308"/>
 			<Orientation y="0.37682"/>
 			<Actor seed="53314"/>
 		</Entity>
 		<Entity uid="13507">
 			<Template>gaia/rock/mediterranean_large</Template>
-			<Player>3</Player>
+			<Player>0</Player>
 			<Position x="190.75757" z="276.92148"/>
 			<Orientation y="-0.48427"/>
 			<Actor seed="58520"/>
 		</Entity>
 		<Entity uid="13508">
 			<Template>gaia/rock/mediterranean_small</Template>
-			<Player>3</Player>
+			<Player>0</Player>
 			<Position x="139.88935" z="292.5619"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="7450"/>
 		</Entity>
 		<Entity uid="13509">
 			<Template>gaia/ore/mediterranean_large</Template>
-			<Player>3</Player>
+			<Player>0</Player>
 			<Position x="151.89301" z="300.6667"/>
 			<Orientation y="0.01"/>
 			<Actor seed="59794"/>
 		</Entity>
 		<Entity uid="13510">
 			<Template>gaia/ore/mediterranean_large</Template>
-			<Player>3</Player>
+			<Player>0</Player>
 			<Position x="212.82721" z="450.97983"/>
 			<Orientation y="0.71755"/>
 			<Actor seed="4730"/>
 		</Entity>
 		<Entity uid="13511">
 			<Template>gaia/ore/mediterranean_large</Template>
-			<Player>3</Player>
+			<Player>0</Player>
 			<Position x="77.56582" z="669.81318"/>
 			<Orientation y="1.27459"/>
 			<Actor seed="37302"/>
 		</Entity>
 		<Entity uid="13512">
 			<Template>gaia/ore/mediterranean_large</Template>
-			<Player>3</Player>
+			<Player>0</Player>
 			<Position x="221.5778" z="1085.81971"/>
 			<Orientation y="3.10227"/>
 			<Actor seed="38918"/>
 		</Entity>
 		<Entity uid="13513">
 			<Template>gaia/rock/mediterranean_small</Template>
-			<Player>3</Player>
+			<Player>0</Player>
 			<Position x="219.49738" z="1070.41175"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="42826"/>
 		</Entity>
 		<Entity uid="13514">
 			<Template>gaia/ore/mediterranean_small</Template>
-			<Player>3</Player>
+			<Player>0</Player>
 			<Position x="187.31714" z="1027.50037"/>
 			<Orientation y="1.90235"/>
 			<Actor seed="36264"/>
 		</Entity>
 		<Entity uid="13515">
 			<Template>gaia/ore/mediterranean_small</Template>
-			<Player>3</Player>
+			<Player>0</Player>
 			<Position x="175.74967" z="637.67286"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="4284"/>

--- a/maps/scenarios/siege_of_numantia.xml
+++ b/maps/scenarios/siege_of_numantia.xml
@@ -560,7 +560,7 @@
 		</Entity>
 		<Entity uid="256">
 			<Template>gaia/fauna_rabbit</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="492.11548" z="911.70337"/>
 			<Orientation y="4.97904"/>
 			<Actor seed="56821"/>
@@ -1765,91 +1765,91 @@
 		</Entity>
 		<Entity uid="524">
 			<Template>gaia/fauna_chicken</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="565.00178" z="671.73548"/>
 			<Orientation y="-0.83997"/>
 			<Actor seed="58782"/>
 		</Entity>
 		<Entity uid="525">
 			<Template>gaia/fauna_chicken</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="558.43158" z="680.29426"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="14964"/>
 		</Entity>
 		<Entity uid="526">
 			<Template>gaia/fauna_chicken</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="562.23243" z="678.37897"/>
 			<Orientation y="0.74363"/>
 			<Actor seed="1756"/>
 		</Entity>
 		<Entity uid="528">
 			<Template>gaia/fauna_chicken</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="560.3783" z="685.49885"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="54776"/>
 		</Entity>
 		<Entity uid="529">
 			<Template>gaia/fauna_chicken</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="555.97681" z="686.29053"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="54382"/>
 		</Entity>
 		<Entity uid="530">
 			<Template>gaia/fauna_chicken</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="555.06373" z="684.14954"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="35434"/>
 		</Entity>
 		<Entity uid="531">
 			<Template>gaia/fauna_chicken</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="553.38483" z="682.62092"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="30264"/>
 		</Entity>
 		<Entity uid="532">
 			<Template>gaia/fauna_chicken</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="550.56202" z="684.21851"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="41958"/>
 		</Entity>
 		<Entity uid="533">
 			<Template>gaia/fauna_chicken</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="561.9997" z="669.1515"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="30836"/>
 		</Entity>
 		<Entity uid="534">
 			<Template>gaia/fauna_chicken</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="564.3296" z="666.20954"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="53080"/>
 		</Entity>
 		<Entity uid="535">
 			<Template>gaia/fauna_chicken</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="564.18049" z="662.59247"/>
 			<Orientation y="0.00205"/>
 			<Actor seed="1258"/>
 		</Entity>
 		<Entity uid="536">
 			<Template>gaia/fauna_chicken</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="564.33716" z="678.90998"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="3552"/>
 		</Entity>
 		<Entity uid="537">
 			<Template>gaia/fauna_chicken</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="567.4787" z="680.89496"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="27854"/>
@@ -1912,70 +1912,70 @@
 		</Entity>
 		<Entity uid="548">
 			<Template>gaia/fruit/apple</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="536.79261" z="688.30658"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="8348"/>
 		</Entity>
 		<Entity uid="549">
 			<Template>gaia/fruit/apple</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="530.23914" z="690.5323"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="48398"/>
 		</Entity>
 		<Entity uid="550">
 			<Template>gaia/fruit/apple</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="619.59803" z="710.90546"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="20028"/>
 		</Entity>
 		<Entity uid="553">
 			<Template>gaia/fruit/apple</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="632.00239" z="709.6023"/>
 			<Orientation y="-2.45307"/>
 			<Actor seed="49248"/>
 		</Entity>
 		<Entity uid="554">
 			<Template>gaia/fruit/apple</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="627.28418" z="582.3"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="11012"/>
 		</Entity>
 		<Entity uid="555">
 			<Template>gaia/fruit/apple</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="571.66297" z="81.85932"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="61388"/>
 		</Entity>
 		<Entity uid="556">
 			<Template>gaia/fruit/apple</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="570.98469" z="52.07374"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="50336"/>
 		</Entity>
 		<Entity uid="557">
 			<Template>gaia/fruit/apple</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="637.57874" z="111.1613"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="3846"/>
 		</Entity>
 		<Entity uid="558">
 			<Template>gaia/fruit/apple</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="188.58017" z="210.83811"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="48646"/>
 		</Entity>
 		<Entity uid="559">
 			<Template>gaia/fruit/apple</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="241.51325" z="210.64844"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="52180"/>
@@ -2031,35 +2031,35 @@
 		</Entity>
 		<Entity uid="582">
 			<Template>gaia/fauna_horse</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="593.8329" z="590.94837"/>
 			<Orientation y="2.94587"/>
 			<Actor seed="63204"/>
 		</Entity>
 		<Entity uid="583">
 			<Template>gaia/fauna_horse</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="591.52894" z="590.58417"/>
 			<Orientation y="2.9488"/>
 			<Actor seed="47926"/>
 		</Entity>
 		<Entity uid="585">
 			<Template>gaia/fauna_horse</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="588.82679" z="590.62818"/>
 			<Orientation y="2.84406"/>
 			<Actor seed="31208"/>
 		</Entity>
 		<Entity uid="587">
 			<Template>gaia/fauna_horse</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="586.22132" z="589.88727"/>
 			<Orientation y="2.91895"/>
 			<Actor seed="42806"/>
 		</Entity>
 		<Entity uid="589">
 			<Template>gaia/fauna_horse</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="583.79444" z="589.52381"/>
 			<Orientation y="3.0624"/>
 			<Actor seed="6874"/>

--- a/maps/scenarios/the_limes_2p.xml
+++ b/maps/scenarios/the_limes_2p.xml
@@ -2410,21 +2410,21 @@
 		</Entity>
 		<Entity uid="453">
 			<Template>gaia/fauna_dog_wolfhound</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="759.59913" z="263.96732"/>
 			<Orientation y="1.0397"/>
 			<Actor seed="34062"/>
 		</Entity>
 		<Entity uid="454">
 			<Template>gaia/fauna_horse</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="757.32288" z="300.6561"/>
 			<Orientation y="1.6697"/>
 			<Actor seed="10550"/>
 		</Entity>
 		<Entity uid="455">
 			<Template>gaia/fauna_horse_marwari</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="749.62043" z="303.61057"/>
 			<Orientation y="0.09551"/>
 			<Actor seed="3478"/>
@@ -3940,14 +3940,14 @@
 		</Entity>
 		<Entity uid="752">
 			<Template>gaia/fauna_cattle_bull</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="818.34327" z="195.0352"/>
 			<Orientation y="0.40178"/>
 			<Actor seed="44120"/>
 		</Entity>
 		<Entity uid="753">
 			<Template>gaia/fauna_cattle_bull</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="824.03693" z="225.96741"/>
 			<Orientation y="-1.62313"/>
 			<Actor seed="27780"/>
@@ -3982,21 +3982,21 @@
 		</Entity>
 		<Entity uid="758">
 			<Template>gaia/fauna_chicken</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="762.57813" z="271.73288"/>
 			<Orientation y="0.588"/>
 			<Actor seed="15000"/>
 		</Entity>
 		<Entity uid="759">
 			<Template>gaia/fauna_chicken</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="764.48505" z="271.90973"/>
 			<Orientation y="-1.1396"/>
 			<Actor seed="10902"/>
 		</Entity>
 		<Entity uid="760">
 			<Template>gaia/fauna_chicken</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="764.88666" z="273.69993"/>
 			<Orientation y="-1.24901"/>
 			<Actor seed="19526"/>
@@ -13241,14 +13241,14 @@
 		</Entity>
 		<Entity uid="2288">
 			<Template>gaia/tree/pine</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="335.31382" z="920.80274"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="21128"/>
 		</Entity>
 		<Entity uid="2289">
 			<Template>gaia/tree/pine</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="355.93122" z="915.37616"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="36838"/>
@@ -39981,35 +39981,35 @@
 		</Entity>
 		<Entity uid="7027">
 			<Template>gaia/fauna_cattle_bull</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="322.94083" z="829.12482"/>
 			<Orientation y="1.979"/>
 			<Actor seed="46958"/>
 		</Entity>
 		<Entity uid="7028">
 			<Template>gaia/fauna_cattle_bull</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="331.51719" z="823.29157"/>
 			<Orientation y="-1.57049"/>
 			<Actor seed="30556"/>
 		</Entity>
 		<Entity uid="7029">
 			<Template>gaia/fauna_chicken</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="322.1497" z="850.7566"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="21178"/>
 		</Entity>
 		<Entity uid="7030">
 			<Template>gaia/fauna_chicken</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="324.55655" z="850.72962"/>
 			<Orientation y="-2.31145"/>
 			<Actor seed="30062"/>
 		</Entity>
 		<Entity uid="7031">
 			<Template>gaia/fauna_chicken</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="321.53513" z="847.72413"/>
 			<Orientation y="1.34063"/>
 			<Actor seed="9866"/>
@@ -40058,14 +40058,14 @@
 		</Entity>
 		<Entity uid="7038">
 			<Template>gaia/fauna_dog_mastiff</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="314.85279" z="848.99646"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="25448"/>
 		</Entity>
 		<Entity uid="7039">
 			<Template>gaia/fauna_donkey</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="322.11167" z="841.85224"/>
 			<Orientation y="1.31032"/>
 			<Actor seed="32632"/>
@@ -40254,28 +40254,28 @@
 		</Entity>
 		<Entity uid="7066">
 			<Template>gaia/fruit/berry_01</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="257.39094" z="842.8553"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="36784"/>
 		</Entity>
 		<Entity uid="7067">
 			<Template>gaia/fruit/berry_01</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="257.8003" z="849.75867"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="35796"/>
 		</Entity>
 		<Entity uid="7068">
 			<Template>gaia/fruit/berry_01</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="253.89856" z="835.89502"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="6980"/>
 		</Entity>
 		<Entity uid="7069">
 			<Template>gaia/fruit/berry_01</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="262.9134" z="856.60071"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="49744"/>
@@ -40536,84 +40536,84 @@
 		</Entity>
 		<Entity uid="7113">
 			<Template>gaia/tree/bush_temperate</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="662.1673" z="357.8613"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="1972"/>
 		</Entity>
 		<Entity uid="7114">
 			<Template>gaia/tree/bush_temperate</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="629.98395" z="349.27482"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="8598"/>
 		</Entity>
 		<Entity uid="7115">
 			<Template>gaia/tree/bush_temperate</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="594.40583" z="310.52726"/>
 			<Orientation y="1.96381"/>
 			<Actor seed="60944"/>
 		</Entity>
 		<Entity uid="7116">
 			<Template>gaia/tree/bush_temperate</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="592.88874" z="305.36493"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="52934"/>
 		</Entity>
 		<Entity uid="7117">
 			<Template>gaia/tree/bush_temperate</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="636.66382" z="353.22617"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="5610"/>
 		</Entity>
 		<Entity uid="7118">
 			<Template>gaia/tree/elm</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="618.09247" z="336.15888"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="16030"/>
 		</Entity>
 		<Entity uid="7119">
 			<Template>gaia/tree/elm</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="614.98163" z="335.51917"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="63546"/>
 		</Entity>
 		<Entity uid="7120">
 			<Template>gaia/tree/elm</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="594.88929" z="316.11805"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="56680"/>
 		</Entity>
 		<Entity uid="7121">
 			<Template>gaia/tree/elm</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="643.0199" z="351.78553"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="63472"/>
 		</Entity>
 		<Entity uid="7122">
 			<Template>gaia/tree/elm</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="638.8213" z="350.80964"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="33582"/>
 		</Entity>
 		<Entity uid="7123">
 			<Template>gaia/tree/maple</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="657.1855" z="358.1359"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="32178"/>
 		</Entity>
 		<Entity uid="7124">
 			<Template>gaia/tree/maple</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="650.58594" z="357.50641"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="15634"/>
@@ -44341,28 +44341,28 @@
 		</Entity>
 		<Entity uid="7823">
 			<Template>gaia/fauna_deer</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="604.30372" z="69.12688"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="12712"/>
 		</Entity>
 		<Entity uid="7824">
 			<Template>gaia/fauna_deer</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="609.27637" z="71.24875"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="29674"/>
 		</Entity>
 		<Entity uid="7825">
 			<Template>gaia/fauna_deer</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="609.84723" z="68.09388"/>
 			<Orientation y="-2.33326"/>
 			<Actor seed="47200"/>
 		</Entity>
 		<Entity uid="7826">
 			<Template>gaia/fauna_deer</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="602.2021" z="64.66813"/>
 			<Orientation y="1.27802"/>
 			<Actor seed="27652"/>

--- a/maps/scenarios/troy_2p.xml
+++ b/maps/scenarios/troy_2p.xml
@@ -2396,238 +2396,238 @@
 		</Entity>
 		<Entity uid="9556">
 			<Template>gaia/tree/oak</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="482.57416" z="1023.5481"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="63257"/>
 		</Entity>
 		<Entity uid="9557">
 			<Template>gaia/tree/oak</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="473.64237" z="1032.94532"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="39459"/>
 		</Entity>
 		<Entity uid="9558">
 			<Template>gaia/tree/oak</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="470.22043" z="1034.94166"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="3518"/>
 		</Entity>
 		<Entity uid="9559">
 			<Template>gaia/tree/oak</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="460.01346" z="1044.53016"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="15712"/>
 		</Entity>
 		<Entity uid="9560">
 			<Template>gaia/tree/oak</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="451.55573" z="1050.74012"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="42280"/>
 		</Entity>
 		<Entity uid="9561">
 			<Template>gaia/tree/oak</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="444.69513" z="1057.18726"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="65387"/>
 		</Entity>
 		<Entity uid="9562">
 			<Template>gaia/tree/oak</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="437.13074" z="1065.39881"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="62017"/>
 		</Entity>
 		<Entity uid="9563">
 			<Template>gaia/tree/oak</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="441.45051" z="1069.47815"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="9735"/>
 		</Entity>
 		<Entity uid="9564">
 			<Template>gaia/tree/oak</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="449.0799" z="1064.5044"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="4348"/>
 		</Entity>
 		<Entity uid="9565">
 			<Template>gaia/tree/oak</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="457.05991" z="1058.66895"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="36031"/>
 		</Entity>
 		<Entity uid="9566">
 			<Template>gaia/tree/oak</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="462.2458" z="1054.8235"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="42785"/>
 		</Entity>
 		<Entity uid="9567">
 			<Template>gaia/tree/oak</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="466.73951" z="1050.20362"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="36799"/>
 		</Entity>
 		<Entity uid="9568">
 			<Template>gaia/tree/oak</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="471.31672" z="1046.83826"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="57634"/>
 		</Entity>
 		<Entity uid="9569">
 			<Template>gaia/tree/oak</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="473.52131" z="1042.485"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="54685"/>
 		</Entity>
 		<Entity uid="9570">
 			<Template>gaia/tree/oak</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="478.48563" z="1037.92566"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="6484"/>
 		</Entity>
 		<Entity uid="9571">
 			<Template>gaia/tree/oak</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="481.9444" z="1032.09668"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="63480"/>
 		</Entity>
 		<Entity uid="9572">
 			<Template>gaia/tree/oak</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="488.15412" z="1028.89551"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="50278"/>
 		</Entity>
 		<Entity uid="9589">
 			<Template>gaia/tree/medit_fan_palm</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="464.30002" z="963.14777"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="19788"/>
 		</Entity>
 		<Entity uid="9590">
 			<Template>gaia/tree/medit_fan_palm</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="455.25666" z="974.34144"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="12690"/>
 		</Entity>
 		<Entity uid="9591">
 			<Template>gaia/tree/medit_fan_palm</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="462.72681" z="980.40894"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="62526"/>
 		</Entity>
 		<Entity uid="9592">
 			<Template>gaia/tree/medit_fan_palm</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="465.59656" z="972.67109"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="35599"/>
 		</Entity>
 		<Entity uid="9593">
 			<Template>gaia/tree/medit_fan_palm</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="468.60038" z="968.11512"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="44335"/>
 		</Entity>
 		<Entity uid="9594">
 			<Template>gaia/tree/medit_fan_palm</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="473.2812" z="971.89637"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="32307"/>
 		</Entity>
 		<Entity uid="9595">
 			<Template>gaia/tree/medit_fan_palm</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="468.3931" z="984.24042"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="31002"/>
 		</Entity>
 		<Entity uid="9596">
 			<Template>gaia/tree/medit_fan_palm</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="474.94877" z="974.82764"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="25584"/>
 		</Entity>
 		<Entity uid="9597">
 			<Template>gaia/tree/palm_palmyra</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="409.45835" z="1040.53113"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="55796"/>
 		</Entity>
 		<Entity uid="9598">
 			<Template>gaia/tree/palm_palmyra</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="415.96659" z="1032.73938"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="36122"/>
 		</Entity>
 		<Entity uid="9599">
 			<Template>gaia/tree/palm_palmyra</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="423.09211" z="1028.26685"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="16129"/>
 		</Entity>
 		<Entity uid="9600">
 			<Template>gaia/tree/palm_palmyra</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="429.6572" z="1020.96412"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="27993"/>
 		</Entity>
 		<Entity uid="9601">
 			<Template>gaia/tree/palm_palmyra</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="442.31812" z="1040.23926"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="54301"/>
 		</Entity>
 		<Entity uid="9605">
 			<Template>gaia/tree/palm_palmyra</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="494.94678" z="999.77497"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="723"/>
 		</Entity>
 		<Entity uid="9606">
 			<Template>gaia/tree/palm_palmyra</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="500.31592" z="1007.53309"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="62060"/>
 		</Entity>
 		<Entity uid="9607">
 			<Template>gaia/tree/palm_palmyra</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="506.79487" z="1011.92096"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="30828"/>
 		</Entity>
 		<Entity uid="9608">
 			<Template>gaia/tree/palm_palmyra</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="513.24964" z="1016.67981"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="45438"/>
@@ -5061,882 +5061,882 @@
 		</Entity>
 		<Entity uid="10179">
 			<Template>gaia/fruit/date</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="510.0677" z="1200.5564"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="40357"/>
 		</Entity>
 		<Entity uid="10180">
 			<Template>gaia/fruit/date</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="513.54029" z="1206.13306"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="58976"/>
 		</Entity>
 		<Entity uid="10181">
 			<Template>gaia/fruit/date</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="507.23704" z="1206.98597"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="38715"/>
 		</Entity>
 		<Entity uid="10182">
 			<Template>gaia/fruit/date</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="520.5055" z="1208.84144"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="58996"/>
 		</Entity>
 		<Entity uid="10183">
 			<Template>gaia/fruit/date</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="546.31751" z="1231.49573"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="5997"/>
 		</Entity>
 		<Entity uid="10184">
 			<Template>gaia/fruit/date</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="537.08582" z="1234.84363"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="56208"/>
 		</Entity>
 		<Entity uid="10185">
 			<Template>gaia/fruit/date</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="527.2027" z="1243.3954"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="50082"/>
 		</Entity>
 		<Entity uid="10186">
 			<Template>gaia/fruit/date</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="605.4693" z="1299.3125"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="38838"/>
 		</Entity>
 		<Entity uid="10187">
 			<Template>gaia/fruit/date</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="604.64197" z="1311.22889"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="7001"/>
 		</Entity>
 		<Entity uid="10188">
 			<Template>gaia/fruit/date</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="321.92246" z="1228.32544"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="22842"/>
 		</Entity>
 		<Entity uid="10189">
 			<Template>gaia/fruit/date</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="315.77396" z="1236.89063"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="38004"/>
 		</Entity>
 		<Entity uid="10190">
 			<Template>gaia/fruit/date</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="320.76801" z="1089.97364"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="10553"/>
 		</Entity>
 		<Entity uid="10191">
 			<Template>gaia/fruit/date</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="312.22498" z="1093.91114"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="59788"/>
 		</Entity>
 		<Entity uid="10192">
 			<Template>gaia/fruit/date</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="315.59235" z="1096.1222"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="46537"/>
 		</Entity>
 		<Entity uid="10193">
 			<Template>gaia/fruit/date</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="273.40506" z="1127.69825"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="1669"/>
 		</Entity>
 		<Entity uid="10194">
 			<Template>gaia/fruit/date</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="398.09809" z="976.0221"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="7545"/>
 		</Entity>
 		<Entity uid="10195">
 			<Template>gaia/fruit/date</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="444.39313" z="945.78626"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="19101"/>
 		</Entity>
 		<Entity uid="10196">
 			<Template>gaia/fruit/date</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="450.95377" z="949.58411"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="15769"/>
 		</Entity>
 		<Entity uid="10197">
 			<Template>gaia/fruit/date</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="444.23243" z="955.91852"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="13162"/>
 		</Entity>
 		<Entity uid="10204">
 			<Template>gaia/fruit/date</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="795.3266" z="993.51191"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="44453"/>
 		</Entity>
 		<Entity uid="10205">
 			<Template>gaia/fruit/date</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="801.82319" z="994.47327"/>
 			<Orientation y="1.92251"/>
 			<Actor seed="45661"/>
 		</Entity>
 		<Entity uid="10206">
 			<Template>gaia/fruit/date</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="809.98011" z="995.91565"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="6293"/>
 		</Entity>
 		<Entity uid="10207">
 			<Template>gaia/fruit/date</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="803.93012" z="992.05774"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="36812"/>
 		</Entity>
 		<Entity uid="10208">
 			<Template>gaia/fruit/date</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="799.99366" z="988.42035"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="31665"/>
 		</Entity>
 		<Entity uid="10209">
 			<Template>gaia/fruit/date</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="808.9798" z="988.67573"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="22683"/>
 		</Entity>
 		<Entity uid="10210">
 			<Template>gaia/fruit/date</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="814.78382" z="1004.70105"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="41801"/>
 		</Entity>
 		<Entity uid="10211">
 			<Template>gaia/fruit/date</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="821.14869" z="1006.95875"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="46101"/>
 		</Entity>
 		<Entity uid="10212">
 			<Template>gaia/fruit/date</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="821.39441" z="998.55079"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="33805"/>
 		</Entity>
 		<Entity uid="10213">
 			<Template>gaia/fruit/date</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="815.4018" z="996.2522"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="26148"/>
 		</Entity>
 		<Entity uid="10214">
 			<Template>gaia/fruit/date</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="806.51063" z="993.13801"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="4760"/>
 		</Entity>
 		<Entity uid="10215">
 			<Template>gaia/fruit/date</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="809.66071" z="996.86054"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="17807"/>
 		</Entity>
 		<Entity uid="10216">
 			<Template>gaia/fruit/date</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="810.5055" z="999.57544"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="24662"/>
 		</Entity>
 		<Entity uid="10217">
 			<Template>gaia/fruit/date</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="815.48328" z="1000.08686"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="43469"/>
 		</Entity>
 		<Entity uid="10218">
 			<Template>gaia/fruit/date</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="854.43232" z="1230.09754"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="8708"/>
 		</Entity>
 		<Entity uid="10219">
 			<Template>gaia/fruit/date</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="861.13386" z="1226.57593"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="13419"/>
 		</Entity>
 		<Entity uid="10220">
 			<Template>gaia/fruit/date</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="857.95307" z="1223.82251"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="47657"/>
 		</Entity>
 		<Entity uid="10221">
 			<Template>gaia/fruit/date</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="865.3205" z="1220.81849"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="12702"/>
 		</Entity>
 		<Entity uid="10222">
 			<Template>gaia/fruit/date</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="863.63111" z="1225.20533"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="20174"/>
 		</Entity>
 		<Entity uid="10223">
 			<Template>gaia/fruit/date</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="863.89814" z="1232.01368"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="16342"/>
 		</Entity>
 		<Entity uid="10224">
 			<Template>gaia/fruit/fig</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="635.49311" z="1382.21338"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="47349"/>
 		</Entity>
 		<Entity uid="10225">
 			<Template>gaia/fruit/fig</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="635.45374" z="1371.12232"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="34895"/>
 		</Entity>
 		<Entity uid="10226">
 			<Template>gaia/fruit/fig</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="644.58863" z="1376.81275"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="8891"/>
 		</Entity>
 		<Entity uid="10227">
 			<Template>gaia/fruit/fig</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="626.50678" z="1373.77344"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="22728"/>
 		</Entity>
 		<Entity uid="10228">
 			<Template>gaia/fruit/fig</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="621.06757" z="1363.72156"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="38942"/>
 		</Entity>
 		<Entity uid="10229">
 			<Template>gaia/fruit/fig</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="615.15278" z="1353.94214"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="47159"/>
 		</Entity>
 		<Entity uid="10230">
 			<Template>gaia/fruit/fig</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="625.08564" z="1354.46119"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="47213"/>
 		</Entity>
 		<Entity uid="10231">
 			<Template>gaia/fruit/fig</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="634.78553" z="1350.77625"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="11323"/>
 		</Entity>
 		<Entity uid="10232">
 			<Template>gaia/fruit/fig</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="634.74079" z="1358.70008"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="38427"/>
 		</Entity>
 		<Entity uid="10233">
 			<Template>gaia/fruit/fig</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="629.24305" z="1362.38538"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="47119"/>
 		</Entity>
 		<Entity uid="10234">
 			<Template>gaia/fruit/fig</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="638.37903" z="1363.52295"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="50229"/>
 		</Entity>
 		<Entity uid="10235">
 			<Template>gaia/fruit/fig</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="659.3199" z="1411.96668"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="43990"/>
 		</Entity>
 		<Entity uid="10236">
 			<Template>gaia/fruit/fig</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="651.4206" z="1422.78223"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="47777"/>
 		</Entity>
 		<Entity uid="10237">
 			<Template>gaia/fruit/fig</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="659.81" z="1404.93262"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="41194"/>
 		</Entity>
 		<Entity uid="10238">
 			<Template>gaia/fruit/fig</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="667.91028" z="1404.08765"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="64662"/>
 		</Entity>
 		<Entity uid="10239">
 			<Template>gaia/fruit/fig</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="668.0799" z="1411.69349"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="20739"/>
 		</Entity>
 		<Entity uid="10240">
 			<Template>gaia/fruit/fig</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="661.05512" z="1418.80628"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="4353"/>
 		</Entity>
 		<Entity uid="10241">
 			<Template>gaia/fruit/fig</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="437.20081" z="1372.91077"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="13353"/>
 		</Entity>
 		<Entity uid="10242">
 			<Template>gaia/fruit/fig</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="442.88855" z="1378.58387"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="12966"/>
 		</Entity>
 		<Entity uid="10243">
 			<Template>gaia/fruit/fig</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="447.98075" z="1368.7251"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="13213"/>
 		</Entity>
 		<Entity uid="10244">
 			<Template>gaia/fruit/fig</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="457.49854" z="1396.74244"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="47740"/>
 		</Entity>
 		<Entity uid="10245">
 			<Template>gaia/fruit/fig</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="465.94245" z="1389.68665"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="38666"/>
 		</Entity>
 		<Entity uid="10246">
 			<Template>gaia/fruit/fig</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="473.23578" z="1392.05262"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="2941"/>
 		</Entity>
 		<Entity uid="10247">
 			<Template>gaia/fruit/fig</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="465.37836" z="1399.1543"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="42323"/>
 		</Entity>
 		<Entity uid="10248">
 			<Template>gaia/fruit/fig</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="479.43268" z="1399.55005"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="43849"/>
 		</Entity>
 		<Entity uid="10249">
 			<Template>gaia/fruit/fig</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="476.3704" z="1384.26697"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="29166"/>
 		</Entity>
 		<Entity uid="10250">
 			<Template>gaia/fruit/fig</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="482.274" z="1380.31373"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="26693"/>
 		</Entity>
 		<Entity uid="10251">
 			<Template>gaia/fruit/fig</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="487.80021" z="1379.98255"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="41713"/>
 		</Entity>
 		<Entity uid="10252">
 			<Template>gaia/fruit/fig</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="490.58655" z="1385.53016"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="62522"/>
 		</Entity>
 		<Entity uid="10253">
 			<Template>gaia/fruit/fig</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="488.83906" z="1395.9131"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="13612"/>
 		</Entity>
 		<Entity uid="10254">
 			<Template>gaia/fruit/fig</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="475.15055" z="1409.9231"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="44283"/>
 		</Entity>
 		<Entity uid="10255">
 			<Template>gaia/fruit/fig</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="465.59827" z="1412.28553"/>
 			<Orientation y="-1.4541"/>
 			<Actor seed="33040"/>
 		</Entity>
 		<Entity uid="10256">
 			<Template>gaia/fruit/fig</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="454.18656" z="1410.72095"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="41363"/>
 		</Entity>
 		<Entity uid="10257">
 			<Template>gaia/fruit/fig</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="446.95356" z="1413.30823"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="6885"/>
 		</Entity>
 		<Entity uid="10258">
 			<Template>gaia/fruit/fig</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="449.47858" z="1424.21143"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="21771"/>
 		</Entity>
 		<Entity uid="10259">
 			<Template>gaia/fruit/fig</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="455.5341" z="1428.08167"/>
 			<Orientation y="1.6429"/>
 			<Actor seed="19173"/>
 		</Entity>
 		<Entity uid="10260">
 			<Template>gaia/fruit/fig</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="472.03174" z="1430.31812"/>
 			<Orientation y="2.17936"/>
 			<Actor seed="18957"/>
 		</Entity>
 		<Entity uid="10261">
 			<Template>gaia/fruit/fig</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="482.59504" z="1424.00062"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="36220"/>
 		</Entity>
 		<Entity uid="10262">
 			<Template>gaia/fruit/fig</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="489.32547" z="1419.01661"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="59638"/>
 		</Entity>
 		<Entity uid="10263">
 			<Template>gaia/fruit/fig</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="491.77396" z="1414.80457"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="43408"/>
 		</Entity>
 		<Entity uid="10264">
 			<Template>gaia/fruit/fig</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="488.26771" z="1412.92603"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="41866"/>
 		</Entity>
 		<Entity uid="10265">
 			<Template>gaia/fruit/fig</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="485.29804" z="1410.51185"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="26730"/>
 		</Entity>
 		<Entity uid="10266">
 			<Template>gaia/fruit/fig</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="479.49872" z="1415.97498"/>
 			<Orientation y="-1.46062"/>
 			<Actor seed="24159"/>
 		</Entity>
 		<Entity uid="10267">
 			<Template>gaia/fruit/fig</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="467.87885" z="1417.12684"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="18201"/>
 		</Entity>
 		<Entity uid="10268">
 			<Template>gaia/fruit/fig</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="461.26771" z="1418.39417"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="28868"/>
 		</Entity>
 		<Entity uid="10269">
 			<Template>gaia/fruit/fig</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="458.6915" z="1417.33216"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="62705"/>
 		</Entity>
 		<Entity uid="10270">
 			<Template>gaia/fruit/fig</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="468.4387" z="1410.14454"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="44653"/>
 		</Entity>
 		<Entity uid="10271">
 			<Template>gaia/fruit/fig</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="477.9632" z="1409.98768"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="14179"/>
 		</Entity>
 		<Entity uid="10272">
 			<Template>gaia/fruit/fig</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="485.1185" z="1411.61316"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="1908"/>
 		</Entity>
 		<Entity uid="10273">
 			<Template>gaia/fruit/fig</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="488.77924" z="1408.20777"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="52469"/>
 		</Entity>
 		<Entity uid="10274">
 			<Template>gaia/fruit/fig</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="489.37812" z="1404.34888"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="22771"/>
 		</Entity>
 		<Entity uid="10275">
 			<Template>gaia/fruit/fig</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="489.81653" z="1395.32715"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="28136"/>
 		</Entity>
 		<Entity uid="10276">
 			<Template>gaia/fruit/fig</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="491.65452" z="1390.71778"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="11809"/>
 		</Entity>
 		<Entity uid="10277">
 			<Template>gaia/fruit/fig</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="494.37473" z="1385.08875"/>
 			<Orientation y="2.63787"/>
 			<Actor seed="7369"/>
 		</Entity>
 		<Entity uid="10278">
 			<Template>gaia/fruit/fig</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="243.31418" z="1270.22083"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="53989"/>
 		</Entity>
 		<Entity uid="10279">
 			<Template>gaia/fruit/fig</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="239.08411" z="1280.94068"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="19721"/>
 		</Entity>
 		<Entity uid="10280">
 			<Template>gaia/fruit/fig</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="243.98618" z="1283.04078"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="61962"/>
 		</Entity>
 		<Entity uid="10281">
 			<Template>gaia/fruit/fig</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="249.64017" z="1283.30494"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="42916"/>
 		</Entity>
 		<Entity uid="10282">
 			<Template>gaia/fruit/fig</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="255.4167" z="1280.88184"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="63481"/>
 		</Entity>
 		<Entity uid="10283">
 			<Template>gaia/fruit/fig</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="262.78907" z="1291.07886"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="12988"/>
 		</Entity>
 		<Entity uid="10284">
 			<Template>gaia/fruit/fig</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="254.67762" z="1297.01539"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="41859"/>
 		</Entity>
 		<Entity uid="10285">
 			<Template>gaia/fruit/fig</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="252.56458" z="1288.10486"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="50460"/>
 		</Entity>
 		<Entity uid="10286">
 			<Template>gaia/fruit/fig</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="265.12452" z="1286.13221"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="19326"/>
 		</Entity>
 		<Entity uid="10287">
 			<Template>gaia/fruit/fig</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="267.50092" z="1283.91932"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="40680"/>
 		</Entity>
 		<Entity uid="10288">
 			<Template>gaia/fruit/fig</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="253.81785" z="1275.99683"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="43700"/>
 		</Entity>
 		<Entity uid="10289">
 			<Template>gaia/fruit/fig</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="290.72565" z="1300.61512"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="16377"/>
 		</Entity>
 		<Entity uid="10290">
 			<Template>gaia/fruit/fig</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="275.16968" z="1304.6941"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="44562"/>
 		</Entity>
 		<Entity uid="10291">
 			<Template>gaia/fruit/fig</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="265.9207" z="1304.55738"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="48356"/>
 		</Entity>
 		<Entity uid="10292">
 			<Template>gaia/fruit/fig</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="185.48133" z="1223.45655"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="25635"/>
 		</Entity>
 		<Entity uid="10293">
 			<Template>gaia/fruit/fig</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="190.5193" z="1221.77991"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="33252"/>
 		</Entity>
 		<Entity uid="10294">
 			<Template>gaia/fruit/fig</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="201.10215" z="1230.77369"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="47336"/>
 		</Entity>
 		<Entity uid="10295">
 			<Template>gaia/fruit/fig</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="214.60654" z="1244.13501"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="54683"/>
 		</Entity>
 		<Entity uid="10296">
 			<Template>gaia/fruit/fig</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="175.30863" z="1203.47059"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="65297"/>
 		</Entity>
 		<Entity uid="10297">
 			<Template>gaia/fruit/fig</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="190.44416" z="1206.79041"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="47757"/>
 		</Entity>
 		<Entity uid="10298">
 			<Template>gaia/fruit/grapes</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="356.81437" z="1105.08436"/>
 			<Orientation y="1.28646"/>
 			<Actor seed="56810"/>
 		</Entity>
 		<Entity uid="10299">
 			<Template>gaia/fruit/grapes</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="359.8595" z="1107.58301"/>
 			<Orientation y="1.44755"/>
 			<Actor seed="23821"/>
 		</Entity>
 		<Entity uid="10300">
 			<Template>gaia/fruit/grapes</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="362.61408" z="1109.57715"/>
 			<Orientation y="1.38538"/>
 			<Actor seed="36061"/>
 		</Entity>
 		<Entity uid="10301">
 			<Template>gaia/fruit/grapes</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="364.12156" z="1112.07398"/>
 			<Orientation y="1.2335"/>
 			<Actor seed="60843"/>
 		</Entity>
 		<Entity uid="10302">
 			<Template>gaia/fruit/grapes</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="364.71583" z="1113.88001"/>
 			<Orientation y="1.58437"/>
 			<Actor seed="6030"/>
 		</Entity>
 		<Entity uid="10303">
 			<Template>gaia/fruit/grapes</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="367.86326" z="1116.01575"/>
 			<Orientation y="1.50263"/>
 			<Actor seed="10749"/>
 		</Entity>
 		<Entity uid="10304">
 			<Template>gaia/fruit/grapes</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="368.87787" z="1119.56641"/>
 			<Orientation y="1.70269"/>
 			<Actor seed="17029"/>
 		</Entity>
 		<Entity uid="10305">
 			<Template>gaia/fruit/grapes</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="371.93836" z="1121.16431"/>
 			<Orientation y="1.57232"/>
 			<Actor seed="45450"/>
 		</Entity>
 		<Entity uid="10306">
 			<Template>gaia/fruit/grapes</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="374.12244" z="1124.25831"/>
 			<Orientation y="1.94095"/>
 			<Actor seed="23232"/>
 		</Entity>
 		<Entity uid="10307">
 			<Template>gaia/fruit/grapes</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="376.17002" z="1127.28858"/>
 			<Orientation y="1.90227"/>
 			<Actor seed="48407"/>
 		</Entity>
 		<Entity uid="10308">
 			<Template>gaia/fruit/grapes</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="377.67981" z="1129.36304"/>
 			<Orientation y="1.65233"/>
 			<Actor seed="29654"/>
 		</Entity>
 		<Entity uid="10309">
 			<Template>gaia/fruit/grapes</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="380.0518" z="1130.65455"/>
 			<Orientation y="1.50802"/>
 			<Actor seed="49429"/>
 		</Entity>
 		<Entity uid="10310">
 			<Template>gaia/fruit/grapes</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="382.73911" z="1133.11915"/>
 			<Orientation y="1.76182"/>
 			<Actor seed="17331"/>
@@ -5950,511 +5950,511 @@
 		</Entity>
 		<Entity uid="10312">
 			<Template>gaia/tree/bush_badlands</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="335.88263" z="1086.64795"/>
 			<Orientation y="3.00324"/>
 			<Actor seed="2572"/>
 		</Entity>
 		<Entity uid="10313">
 			<Template>gaia/tree/bush_badlands</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="394.4098" z="1183.3932"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="13985"/>
 		</Entity>
 		<Entity uid="10314">
 			<Template>gaia/tree/bush_badlands</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="388.2815" z="1191.31263"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="47561"/>
 		</Entity>
 		<Entity uid="10315">
 			<Template>gaia/tree/bush_badlands</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="479.7411" z="1170.07435"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="42199"/>
 		</Entity>
 		<Entity uid="10316">
 			<Template>gaia/tree/bush_badlands</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="476.32828" z="1163.2876"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="16068"/>
 		</Entity>
 		<Entity uid="10317">
 			<Template>gaia/tree/bush_badlands</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="469.03794" z="1165.23755"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="62306"/>
 		</Entity>
 		<Entity uid="10318">
 			<Template>gaia/tree/bush_badlands</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="485.31019" z="1165.66578"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="14542"/>
 		</Entity>
 		<Entity uid="10319">
 			<Template>gaia/tree/palm_doum</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="515.7433" z="848.71851"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="41978"/>
 		</Entity>
 		<Entity uid="10320">
 			<Template>gaia/tree/palm_doum</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="527.20331" z="845.26978"/>
 			<Orientation y="-0.37346"/>
 			<Actor seed="22017"/>
 		</Entity>
 		<Entity uid="10321">
 			<Template>gaia/tree/palm_doum</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="613.36591" z="850.4198"/>
 			<Orientation y="0.61481"/>
 			<Actor seed="49212"/>
 		</Entity>
 		<Entity uid="10322">
 			<Template>gaia/tree/palm_doum</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="687.37024" z="895.38501"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="27524"/>
 		</Entity>
 		<Entity uid="10323">
 			<Template>gaia/tree/palm_doum</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="692.6631" z="905.56452"/>
 			<Orientation y="-2.9917"/>
 			<Actor seed="11268"/>
 		</Entity>
 		<Entity uid="10324">
 			<Template>gaia/tree/palm_doum</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="691.39087" z="900.14551"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="23402"/>
 		</Entity>
 		<Entity uid="10325">
 			<Template>gaia/tree/palm_doum</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="677.74854" z="890.6324"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="48887"/>
 		</Entity>
 		<Entity uid="10326">
 			<Template>gaia/tree/palm_doum</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="664.39948" z="881.115"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="41080"/>
 		</Entity>
 		<Entity uid="10327">
 			<Template>gaia/tree/palm_doum</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="672.58002" z="887.27167"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="32627"/>
 		</Entity>
 		<Entity uid="10328">
 			<Template>gaia/tree/palm_doum</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="686.547" z="892.24683"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="38535"/>
 		</Entity>
 		<Entity uid="10329">
 			<Template>gaia/tree/palm_doum</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="696.41272" z="908.68427"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="2900"/>
 		</Entity>
 		<Entity uid="10330">
 			<Template>gaia/tree/palm_doum</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="702.28992" z="913.31568"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="50773"/>
 		</Entity>
 		<Entity uid="10331">
 			<Template>gaia/tree/palm_doum</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="710.31153" z="919.93146"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="31416"/>
 		</Entity>
 		<Entity uid="10334">
 			<Template>gaia/tree/palm_doum</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="843.6059" z="1057.05164"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="23513"/>
 		</Entity>
 		<Entity uid="10335">
 			<Template>gaia/tree/palm_doum</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="848.0312" z="1057.9557"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="4513"/>
 		</Entity>
 		<Entity uid="10336">
 			<Template>gaia/tree/palm_doum</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="866.23401" z="1057.39332"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="30815"/>
 		</Entity>
 		<Entity uid="10337">
 			<Template>gaia/tree/palm_doum</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="876.4944" z="1060.48511"/>
 			<Orientation y="-2.68053"/>
 			<Actor seed="12493"/>
 		</Entity>
 		<Entity uid="10338">
 			<Template>gaia/tree/palm_doum</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="883.98548" z="1058.1128"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="43857"/>
 		</Entity>
 		<Entity uid="10339">
 			<Template>gaia/tree/palm_doum</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="884.07306" z="1069.70447"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="56490"/>
 		</Entity>
 		<Entity uid="10340">
 			<Template>gaia/tree/palm_doum</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="890.38123" z="1075.64478"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="20312"/>
 		</Entity>
 		<Entity uid="10341">
 			<Template>gaia/tree/palm_palmyra</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="619.162" z="860.7992"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="10289"/>
 		</Entity>
 		<Entity uid="10344">
 			<Template>gaia/tree/palm_palmyra</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="628.10761" z="1167.28724"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="29501"/>
 		</Entity>
 		<Entity uid="10345">
 			<Template>gaia/tree/palm_palmyra</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="651.43787" z="1180.40467"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="62674"/>
 		</Entity>
 		<Entity uid="10346">
 			<Template>gaia/tree/palm_palmyra</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="656.54651" z="1184.57264"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="23775"/>
 		</Entity>
 		<Entity uid="10347">
 			<Template>gaia/tree/palm_palmyra</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="665.9875" z="1196.72901"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="11613"/>
 		</Entity>
 		<Entity uid="10348">
 			<Template>gaia/tree/palm_palmyra</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="644.03827" z="1310.75855"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="28382"/>
 		</Entity>
 		<Entity uid="10349">
 			<Template>gaia/tree/palm_palmyra</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="634.9242" z="1335.95862"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="48985"/>
 		</Entity>
 		<Entity uid="10350">
 			<Template>gaia/tree/palm_palmyra</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="645.33832" z="1340.16443"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="23268"/>
 		</Entity>
 		<Entity uid="10351">
 			<Template>gaia/tree/palm_palmyra</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="644.5448" z="1348.72205"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="29538"/>
 		</Entity>
 		<Entity uid="10352">
 			<Template>gaia/tree/palm_palmyra</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="584.95301" z="1338.41504"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="22039"/>
 		</Entity>
 		<Entity uid="10353">
 			<Template>gaia/tree/palm_palmyra</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="590.31159" z="1339.77747"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="43253"/>
 		</Entity>
 		<Entity uid="10354">
 			<Template>gaia/tree/palm_palmyra</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="579.88324" z="1349.24402"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="51331"/>
 		</Entity>
 		<Entity uid="10355">
 			<Template>gaia/tree/palm_palmyra</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="501.29316" z="1259.08545"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="50342"/>
 		</Entity>
 		<Entity uid="10356">
 			<Template>gaia/tree/palm_palmyra</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="491.84308" z="1255.82007"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="45030"/>
 		</Entity>
 		<Entity uid="10357">
 			<Template>gaia/tree/palm_palmyra</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="498.71894" z="1254.87696"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="51477"/>
 		</Entity>
 		<Entity uid="10358">
 			<Template>gaia/tree/palm_palmyra</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="503.60578" z="1254.4015"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="30526"/>
 		</Entity>
 		<Entity uid="10359">
 			<Template>gaia/tree/palm_palmyra</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="505.44092" z="1248.70191"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="64800"/>
 		</Entity>
 		<Entity uid="10360">
 			<Template>gaia/tree/palm_palmyra</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="511.26261" z="1247.97181"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="18506"/>
 		</Entity>
 		<Entity uid="10361">
 			<Template>gaia/tree/palm_palmyra</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="482.12604" z="1166.72767"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="52221"/>
 		</Entity>
 		<Entity uid="10362">
 			<Template>gaia/tree/palm_palmyra</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="415.41471" z="1205.58814"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="25533"/>
 		</Entity>
 		<Entity uid="10363">
 			<Template>gaia/tree/palm_palmyra</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="329.76093" z="951.7884"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="52641"/>
 		</Entity>
 		<Entity uid="10364">
 			<Template>gaia/tree/palm_palmyra</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="332.64759" z="955.2464"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="41330"/>
 		</Entity>
 		<Entity uid="10365">
 			<Template>gaia/tree/palm_palmyra</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="305.25199" z="970.48053"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="62227"/>
 		</Entity>
 		<Entity uid="10366">
 			<Template>gaia/tree/palm_palmyra</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="312.92533" z="968.42463"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="60398"/>
 		</Entity>
 		<Entity uid="10367">
 			<Template>gaia/tree/palm_palmyra</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="316.97046" z="967.9803"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="52736"/>
 		</Entity>
 		<Entity uid="10368">
 			<Template>gaia/tree/palm_palmyra</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="278.86408" z="999.3974"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="52224"/>
 		</Entity>
 		<Entity uid="10369">
 			<Template>gaia/tree/palm_palmyra</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="281.67743" z="993.14771"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="46339"/>
 		</Entity>
 		<Entity uid="10371">
 			<Template>gaia/tree/palm_palmyra</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="241.49344" z="1039.30188"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="33540"/>
 		</Entity>
 		<Entity uid="10372">
 			<Template>gaia/tree/palm_palmyra</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="244.49262" z="1122.31446"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="62219"/>
 		</Entity>
 		<Entity uid="10373">
 			<Template>gaia/tree/palm_palmyra</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="211.62372" z="1207.13794"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="20323"/>
 		</Entity>
 		<Entity uid="10374">
 			<Template>gaia/tree/palm_palmyra</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="201.51862" z="1211.09913"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="37615"/>
 		</Entity>
 		<Entity uid="10375">
 			<Template>gaia/tree/palm_palmyra</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="224.80362" z="1248.86805"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="53599"/>
 		</Entity>
 		<Entity uid="10376">
 			<Template>gaia/tree/palm_palmyra</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="224.56278" z="1264.4834"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="44562"/>
 		</Entity>
 		<Entity uid="10377">
 			<Template>gaia/tree/palm_palmyra</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="232.37867" z="1257.60596"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="59416"/>
 		</Entity>
 		<Entity uid="10378">
 			<Template>gaia/tree/palm_palmyra</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="234.3263" z="1264.13794"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="53789"/>
 		</Entity>
 		<Entity uid="10379">
 			<Template>gaia/tree/palm_palmyra</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="231.7435" z="1275.1808"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="20032"/>
 		</Entity>
 		<Entity uid="10380">
 			<Template>gaia/tree/palm_palmyra</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="301.44996" z="1288.15247"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="20540"/>
 		</Entity>
 		<Entity uid="10381">
 			<Template>gaia/tree/palm_palmyra</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="294.44996" z="1288.90027"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="64189"/>
 		</Entity>
 		<Entity uid="10382">
 			<Template>gaia/tree/palm_palmyra</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="285.7045" z="1289.42054"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="15531"/>
 		</Entity>
 		<Entity uid="10383">
 			<Template>gaia/tree/palm_palmyra</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="280.70447" z="1286.1089"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="24347"/>
 		</Entity>
 		<Entity uid="10384">
 			<Template>gaia/tree/palm_palmyra</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="277.20719" z="1281.46009"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="52958"/>
 		</Entity>
 		<Entity uid="10385">
 			<Template>gaia/tree/palm_palmyra</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="264.494" z="1310.96692"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="57444"/>
 		</Entity>
 		<Entity uid="10386">
 			<Template>gaia/tree/palm_palmyra</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="285.16224" z="1307.03553"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="49430"/>
 		</Entity>
 		<Entity uid="10387">
 			<Template>gaia/tree/palm_palmyra</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="298.98426" z="1310.83301"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="37729"/>
 		</Entity>
 		<Entity uid="10388">
 			<Template>gaia/tree/palm_palmyra</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="316.95063" z="1337.35108"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="62513"/>
 		</Entity>
 		<Entity uid="10389">
 			<Template>gaia/tree/palm_palmyra</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="318.34867" z="1319.5608"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="37131"/>
@@ -6524,343 +6524,343 @@
 		</Entity>
 		<Entity uid="10407">
 			<Template>gaia/tree/carob</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="762.80988" z="984.04584"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="36820"/>
 		</Entity>
 		<Entity uid="10408">
 			<Template>gaia/tree/carob</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="881.95588" z="1210.0652"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="53013"/>
 		</Entity>
 		<Entity uid="10409">
 			<Template>gaia/tree/carob</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="864.51124" z="1244.99061"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="48227"/>
 		</Entity>
 		<Entity uid="10410">
 			<Template>gaia/tree/carob</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="895.43982" z="1229.32056"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="27845"/>
 		</Entity>
 		<Entity uid="10411">
 			<Template>gaia/tree/carob</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="848.2317" z="1272.65052"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="48464"/>
 		</Entity>
 		<Entity uid="10412">
 			<Template>gaia/tree/carob</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="758.65076" z="1333.92066"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="51104"/>
 		</Entity>
 		<Entity uid="10413">
 			<Template>gaia/tree/carob</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="762.22138" z="1330.42933"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="14096"/>
 		</Entity>
 		<Entity uid="10414">
 			<Template>gaia/tree/carob</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="772.1225" z="1318.31629"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="47025"/>
 		</Entity>
 		<Entity uid="10415">
 			<Template>gaia/tree/carob</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="773.63038" z="1340.47376"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="40033"/>
 		</Entity>
 		<Entity uid="10416">
 			<Template>gaia/tree/carob</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="777.81391" z="1331.92542"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="31470"/>
 		</Entity>
 		<Entity uid="10417">
 			<Template>gaia/tree/carob</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="786.73426" z="1312.82081"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="46458"/>
 		</Entity>
 		<Entity uid="10418">
 			<Template>gaia/tree/carob</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="790.63062" z="1333.46778"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="4383"/>
 		</Entity>
 		<Entity uid="10421">
 			<Template>gaia/tree/carob</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="738.84101" z="942.0625"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="63208"/>
 		</Entity>
 		<Entity uid="10422">
 			<Template>gaia/tree/carob</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="750.72376" z="942.477"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="60162"/>
 		</Entity>
 		<Entity uid="10423">
 			<Template>gaia/tree/carob</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="620.18378" z="851.498"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="21052"/>
 		</Entity>
 		<Entity uid="10424">
 			<Template>gaia/tree/carob</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="606.7035" z="840.20862"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="1410"/>
 		</Entity>
 		<Entity uid="10425">
 			<Template>gaia/tree/carob</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="656.02778" z="873.91334"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="58994"/>
 		</Entity>
 		<Entity uid="10426">
 			<Template>gaia/tree/carob</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="520.83466" z="855.73353"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="26823"/>
 		</Entity>
 		<Entity uid="10427">
 			<Template>gaia/tree/carob</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="319.67093" z="951.85743"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="30180"/>
 		</Entity>
 		<Entity uid="10428">
 			<Template>gaia/tree/carob</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="263.6468" z="1016.66626"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="32183"/>
 		</Entity>
 		<Entity uid="10429">
 			<Template>gaia/tree/carob</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="184.55335" z="1105.42151"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="33825"/>
 		</Entity>
 		<Entity uid="10430">
 			<Template>gaia/tree/carob</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="703.37287" z="1411.69105"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="40984"/>
 		</Entity>
 		<Entity uid="10431">
 			<Template>gaia/tree/carob</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="672.2154" z="1452.72217"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="61963"/>
 		</Entity>
 		<Entity uid="10432">
 			<Template>gaia/tree/carob</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="698.53815" z="1439.80542"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="38610"/>
 		</Entity>
 		<Entity uid="10433">
 			<Template>gaia/tree/carob</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="731.2378" z="1418.00733"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="30110"/>
 		</Entity>
 		<Entity uid="10434">
 			<Template>gaia/tree/carob</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="768.7295" z="1364.83948"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="55216"/>
 		</Entity>
 		<Entity uid="10435">
 			<Template>gaia/tree/carob</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="773.61823" z="1371.05713"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="45841"/>
 		</Entity>
 		<Entity uid="10436">
 			<Template>gaia/tree/carob</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="765.39136" z="1378.36133"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="48190"/>
 		</Entity>
 		<Entity uid="10437">
 			<Template>gaia/tree/carob</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="757.3415" z="1373.99146"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="64812"/>
 		</Entity>
 		<Entity uid="10438">
 			<Template>gaia/tree/carob</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="784.05848" z="1362.64661"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="6895"/>
 		</Entity>
 		<Entity uid="10439">
 			<Template>gaia/tree/carob</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="794.6562" z="1353.31617"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="44144"/>
 		</Entity>
 		<Entity uid="10440">
 			<Template>gaia/tree/carob</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="789.97059" z="1348.39905"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="7010"/>
 		</Entity>
 		<Entity uid="10441">
 			<Template>gaia/tree/carob</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="782.9549" z="1349.7732"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="37726"/>
 		</Entity>
 		<Entity uid="10442">
 			<Template>gaia/tree/carob</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="562.21125" z="1431.99207"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="26207"/>
 		</Entity>
 		<Entity uid="10443">
 			<Template>gaia/tree/carob</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="591.83771" z="1436.57947"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="56847"/>
 		</Entity>
 		<Entity uid="10444">
 			<Template>gaia/tree/carob</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="591.60651" z="1446.49854"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="28946"/>
 		</Entity>
 		<Entity uid="10445">
 			<Template>gaia/tree/carob</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="598.35096" z="1442.60718"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="30114"/>
 		</Entity>
 		<Entity uid="10446">
 			<Template>gaia/tree/cedar_atlas_2_young</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="545.69941" z="1418.51417"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="3730"/>
 		</Entity>
 		<Entity uid="10447">
 			<Template>gaia/tree/cedar_atlas_2_young</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="625.32178" z="1447.19397"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="58588"/>
 		</Entity>
 		<Entity uid="10448">
 			<Template>gaia/tree/cedar_atlas_2_young</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="631.47175" z="1452.53626"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="55867"/>
 		</Entity>
 		<Entity uid="10449">
 			<Template>gaia/tree/cedar_atlas_2_young</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="644.25641" z="1473.8158"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="49157"/>
 		</Entity>
 		<Entity uid="10450">
 			<Template>gaia/tree/cedar_atlas_2_young</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="656.95075" z="1456.04615"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="14436"/>
 		</Entity>
 		<Entity uid="10451">
 			<Template>gaia/tree/cedar_atlas_2_young</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="647.05188" z="1447.75611"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="8222"/>
 		</Entity>
 		<Entity uid="10452">
 			<Template>gaia/tree/cedar_atlas_2_young</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="652.839" z="1446.1891"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="62652"/>
 		</Entity>
 		<Entity uid="10453">
 			<Template>gaia/tree/cedar_atlas_2_young</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="688.78614" z="1414.28797"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="23260"/>
 		</Entity>
 		<Entity uid="10454">
 			<Template>gaia/tree/cedar_atlas_2_young</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="709.3559" z="1417.93299"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="39646"/>
 		</Entity>
 		<Entity uid="10455">
 			<Template>gaia/tree/cedar_atlas_2_young</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="688.18519" z="1428.10206"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="33515"/>
 		</Entity>
 		<Entity uid="10456">
 			<Template>gaia/tree/cedar_atlas_2_young</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="725.08851" z="1422.5348"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="32967"/>
 		</Entity>
 		<Entity uid="10457">
 			<Template>gaia/tree/cedar_atlas_2_young</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="728.94007" z="1403.82557"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="23421"/>
@@ -6916,924 +6916,924 @@
 		</Entity>
 		<Entity uid="10465">
 			<Template>gaia/tree/cypress</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="711.23401" z="1397.08545"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="54907"/>
 		</Entity>
 		<Entity uid="10466">
 			<Template>gaia/tree/cypress</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="719.4001" z="1403.78101"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="22009"/>
 		</Entity>
 		<Entity uid="10467">
 			<Template>gaia/tree/cypress</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="737.75263" z="1388.78565"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="63588"/>
 		</Entity>
 		<Entity uid="10468">
 			<Template>gaia/tree/cypress</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="747.0912" z="1395.00403"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="29784"/>
 		</Entity>
 		<Entity uid="10469">
 			<Template>gaia/tree/cypress</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="739.97022" z="1405.26075"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="47038"/>
 		</Entity>
 		<Entity uid="10470">
 			<Template>gaia/tree/cypress</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="655.95051" z="1433.05774"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="2658"/>
 		</Entity>
 		<Entity uid="10471">
 			<Template>gaia/tree/cypress</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="664.34302" z="1440.17701"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="56958"/>
 		</Entity>
 		<Entity uid="10472">
 			<Template>gaia/tree/cypress</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="658.57367" z="1449.39356"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="3794"/>
 		</Entity>
 		<Entity uid="10473">
 			<Template>gaia/tree/cypress</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="614.27338" z="1441.40357"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="21434"/>
 		</Entity>
 		<Entity uid="10474">
 			<Template>gaia/tree/cypress</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="603.97114" z="1449.71924"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="32985"/>
 		</Entity>
 		<Entity uid="10475">
 			<Template>gaia/tree/cypress</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="615.03364" z="1449.2284"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="11687"/>
 		</Entity>
 		<Entity uid="10476">
 			<Template>gaia/tree/cypress</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="516.62024" z="1417.14954"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="37604"/>
 		</Entity>
 		<Entity uid="10477">
 			<Template>gaia/tree/cypress</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="503.75678" z="1416.00953"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="43408"/>
 		</Entity>
 		<Entity uid="10478">
 			<Template>gaia/tree/cypress</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="511.46854" z="1414.51294"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="10588"/>
 		</Entity>
 		<Entity uid="10479">
 			<Template>gaia/tree/cypress</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="507.25834" z="1423.78614"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="41584"/>
 		</Entity>
 		<Entity uid="10480">
 			<Template>gaia/tree/cypress</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="532.21698" z="1420.70667"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="3846"/>
 		</Entity>
 		<Entity uid="10481">
 			<Template>gaia/tree/cypress</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="537.62647" z="1412.00623"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="33514"/>
 		</Entity>
 		<Entity uid="10482">
 			<Template>gaia/tree/cypress</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="539.83149" z="1416.71583"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="4343"/>
 		</Entity>
 		<Entity uid="10483">
 			<Template>gaia/tree/cypress</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="415.66977" z="1401.12134"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="41777"/>
 		</Entity>
 		<Entity uid="10484">
 			<Template>gaia/tree/cypress</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="421.839" z="1404.26734"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="25844"/>
 		</Entity>
 		<Entity uid="10485">
 			<Template>gaia/tree/cypress</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="376.30481" z="1387.0398"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="56929"/>
 		</Entity>
 		<Entity uid="10486">
 			<Template>gaia/tree/cypress</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="327.68281" z="1344.98755"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="12108"/>
 		</Entity>
 		<Entity uid="10487">
 			<Template>gaia/tree/cypress</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="334.50422" z="1355.1067"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="57834"/>
 		</Entity>
 		<Entity uid="10488">
 			<Template>gaia/tree/cypress</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="238.51172" z="1258.5265"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="45435"/>
 		</Entity>
 		<Entity uid="10489">
 			<Template>gaia/tree/cypress</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="216.25937" z="1260.22864"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="57084"/>
 		</Entity>
 		<Entity uid="10490">
 			<Template>gaia/tree/cypress</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="198.10166" z="1251.66541"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="63059"/>
 		</Entity>
 		<Entity uid="10491">
 			<Template>gaia/tree/cypress</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="198.55906" z="1247.66175"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="29821"/>
 		</Entity>
 		<Entity uid="10492">
 			<Template>gaia/tree/cypress</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="205.94016" z="1236.43348"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="47594"/>
 		</Entity>
 		<Entity uid="10493">
 			<Template>gaia/tree/cypress</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="209.52607" z="1233.22974"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="63538"/>
 		</Entity>
 		<Entity uid="10494">
 			<Template>gaia/tree/cypress</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="167.68592" z="1197.37317"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="15218"/>
 		</Entity>
 		<Entity uid="10495">
 			<Template>gaia/tree/cypress</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="147.5597" z="1183.21607"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="62222"/>
 		</Entity>
 		<Entity uid="10496">
 			<Template>gaia/tree/cypress</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="151.67631" z="1172.59412"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="20774"/>
 		</Entity>
 		<Entity uid="10497">
 			<Template>gaia/tree/cypress</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="477.2797" z="1343.58362"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="21304"/>
 		</Entity>
 		<Entity uid="10498">
 			<Template>gaia/tree/cypress</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="482.84058" z="1347.11207"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="27779"/>
 		</Entity>
 		<Entity uid="10499">
 			<Template>gaia/tree/cypress</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="499.5785" z="1377.08997"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="64213"/>
 		</Entity>
 		<Entity uid="10500">
 			<Template>gaia/tree/cypress</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="506.26767" z="1375.7898"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="28463"/>
 		</Entity>
 		<Entity uid="10501">
 			<Template>gaia/tree/cypress</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="577.71137" z="1275.76087"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="48823"/>
 		</Entity>
 		<Entity uid="10502">
 			<Template>gaia/tree/cypress</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="627.1031" z="1161.09449"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="42172"/>
 		</Entity>
 		<Entity uid="10503">
 			<Template>gaia/tree/cypress</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="587.16749" z="947.9358"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="47894"/>
 		</Entity>
 		<Entity uid="10504">
 			<Template>gaia/tree/cypress</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="593.10853" z="943.84644"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="27723"/>
 		</Entity>
 		<Entity uid="10505">
 			<Template>gaia/tree/cypress</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="590.10431" z="952.6214"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="21705"/>
 		</Entity>
 		<Entity uid="10506">
 			<Template>gaia/tree/cypress</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="536.42634" z="844.8235"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="14850"/>
 		</Entity>
 		<Entity uid="10507">
 			<Template>gaia/tree/cypress</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="511.93863" z="844.27802"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="40141"/>
 		</Entity>
 		<Entity uid="10508">
 			<Template>gaia/tree/cypress</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="631.01758" z="870.49067"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="39892"/>
 		</Entity>
 		<Entity uid="10509">
 			<Template>gaia/tree/cypress</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="631.17981" z="861.37684"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="55896"/>
 		</Entity>
 		<Entity uid="10510">
 			<Template>gaia/tree/cypress</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="670.08478" z="882.25965"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="57931"/>
 		</Entity>
 		<Entity uid="10511">
 			<Template>gaia/tree/cypress</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="720.09693" z="947.57905"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="55502"/>
 		</Entity>
 		<Entity uid="10512">
 			<Template>gaia/tree/cypress</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="722.71027" z="940.83191"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="58096"/>
 		</Entity>
 		<Entity uid="10513">
 			<Template>gaia/tree/cypress</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="724.38196" z="945.0539"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="16935"/>
 		</Entity>
 		<Entity uid="10514">
 			<Template>gaia/tree/cypress</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="740.71772" z="959.8473"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="32686"/>
 		</Entity>
 		<Entity uid="10515">
 			<Template>gaia/tree/cypress</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="744.32728" z="955.11976"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="29628"/>
 		</Entity>
 		<Entity uid="10516">
 			<Template>gaia/tree/cypress</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="828.78138" z="999.79725"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="25934"/>
 		</Entity>
 		<Entity uid="10517">
 			<Template>gaia/tree/cypress</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="823.74598" z="1014.51783"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="5696"/>
 		</Entity>
 		<Entity uid="10518">
 			<Template>gaia/tree/cypress</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="829.95289" z="1009.61689"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="33455"/>
 		</Entity>
 		<Entity uid="10519">
 			<Template>gaia/tree/cypress</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="826.06464" z="1005.25403"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="61267"/>
 		</Entity>
 		<Entity uid="10520">
 			<Template>gaia/tree/cypress</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="826.83997" z="1010.53351"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="19013"/>
 		</Entity>
 		<Entity uid="10521">
 			<Template>gaia/tree/cypress</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="884.55121" z="1066.08191"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="39248"/>
 		</Entity>
 		<Entity uid="10522">
 			<Template>gaia/tree/cypress</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="884.39472" z="1075.33985"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="13424"/>
 		</Entity>
 		<Entity uid="10523">
 			<Template>gaia/tree/cypress</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="888.02729" z="1070.73035"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="47105"/>
 		</Entity>
 		<Entity uid="10524">
 			<Template>gaia/tree/cypress</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="890.93897" z="1070.17908"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="20996"/>
 		</Entity>
 		<Entity uid="10525">
 			<Template>gaia/tree/cypress</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="891.99585" z="1083.55225"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="18795"/>
 		</Entity>
 		<Entity uid="10526">
 			<Template>gaia/tree/cypress</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="857.67835" z="1056.3683"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="13733"/>
 		</Entity>
 		<Entity uid="10527">
 			<Template>gaia/tree/cypress</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="847.49927" z="1062.3147"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="14688"/>
 		</Entity>
 		<Entity uid="10528">
 			<Template>gaia/tree/cypress</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="856.13044" z="1129.09437"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="48967"/>
 		</Entity>
 		<Entity uid="10529">
 			<Template>gaia/tree/cypress</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="862.42017" z="1135.6515"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="6160"/>
 		</Entity>
 		<Entity uid="10530">
 			<Template>gaia/tree/date_palm</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="862.97822" z="1113.95533"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="46550"/>
 		</Entity>
 		<Entity uid="10531">
 			<Template>gaia/tree/date_palm</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="908.30365" z="1176.98426"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="39676"/>
 		</Entity>
 		<Entity uid="10532">
 			<Template>gaia/tree/date_palm</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="899.51948" z="1184.49683"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="23663"/>
 		</Entity>
 		<Entity uid="10533">
 			<Template>gaia/tree/date_palm</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="880.25214" z="1226.11402"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="29022"/>
 		</Entity>
 		<Entity uid="10534">
 			<Template>gaia/tree/date_palm</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="883.88361" z="1235.12684"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="47583"/>
 		</Entity>
 		<Entity uid="10535">
 			<Template>gaia/tree/date_palm</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="885.0171" z="1223.27747"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="46961"/>
 		</Entity>
 		<Entity uid="10536">
 			<Template>gaia/tree/date_palm</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="896.46338" z="1220.01197"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="53196"/>
 		</Entity>
 		<Entity uid="10537">
 			<Template>gaia/tree/date_palm</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="798.4109" z="1340.45496"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="11096"/>
 		</Entity>
 		<Entity uid="10538">
 			<Template>gaia/tree/date_palm</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="799.16004" z="1347.14637"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="49139"/>
 		</Entity>
 		<Entity uid="10539">
 			<Template>gaia/tree/date_palm</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="878.72376" z="1259.06788"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="9968"/>
 		</Entity>
 		<Entity uid="10540">
 			<Template>gaia/tree/date_palm</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="857.66059" z="1281.80604"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="1841"/>
 		</Entity>
 		<Entity uid="10541">
 			<Template>gaia/tree/date_palm</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="858.61243" z="1268.20032"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="32028"/>
 		</Entity>
 		<Entity uid="10542">
 			<Template>gaia/tree/date_palm</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="702.69288" z="1148.53455"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="24273"/>
 		</Entity>
 		<Entity uid="10543">
 			<Template>gaia/tree/date_palm</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="711.17707" z="1155.81946"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="45188"/>
 		</Entity>
 		<Entity uid="10544">
 			<Template>gaia/tree/date_palm</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="709.2848" z="1151.57325"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="24943"/>
 		</Entity>
 		<Entity uid="10545">
 			<Template>gaia/tree/date_palm</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="716.26636" z="1157.02662"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="13711"/>
 		</Entity>
 		<Entity uid="10546">
 			<Template>gaia/tree/date_palm</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="722.04175" z="1163.42066"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="12975"/>
 		</Entity>
 		<Entity uid="10547">
 			<Template>gaia/tree/date_palm</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="696.86573" z="1144.09754"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="7749"/>
 		</Entity>
 		<Entity uid="10548">
 			<Template>gaia/tree/date_palm</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="668.46717" z="1117.62012"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="45605"/>
 		</Entity>
 		<Entity uid="10549">
 			<Template>gaia/tree/date_palm</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="642.89295" z="1206.70289"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="42876"/>
 		</Entity>
 		<Entity uid="10550">
 			<Template>gaia/tree/date_palm</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="649.81043" z="1199.72193"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="61777"/>
 		</Entity>
 		<Entity uid="10551">
 			<Template>gaia/tree/date_palm</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="530.04291" z="1230.90564"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="9467"/>
 		</Entity>
 		<Entity uid="10552">
 			<Template>gaia/tree/date_palm</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="537.51081" z="1227.34632"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="23144"/>
 		</Entity>
 		<Entity uid="10553">
 			<Template>gaia/tree/date_palm</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="520.1692" z="1244.71326"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="23181"/>
 		</Entity>
 		<Entity uid="10554">
 			<Template>gaia/tree/date_palm</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="518.8636" z="1238.81165"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="61291"/>
 		</Entity>
 		<Entity uid="10555">
 			<Template>gaia/tree/date_palm</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="522.71851" z="1237.33216"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="286"/>
 		</Entity>
 		<Entity uid="10556">
 			<Template>gaia/tree/date_palm</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="508.82502" z="1241.58521"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="41141"/>
 		</Entity>
 		<Entity uid="10557">
 			<Template>gaia/tree/date_palm</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="518.3205" z="1231.17884"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="23503"/>
 		</Entity>
 		<Entity uid="10558">
 			<Template>gaia/tree/date_palm</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="524.39362" z="1228.92591"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="52986"/>
 		</Entity>
 		<Entity uid="10559">
 			<Template>gaia/tree/date_palm</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="529.02833" z="1224.11365"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="42567"/>
 		</Entity>
 		<Entity uid="10560">
 			<Template>gaia/tree/date_palm</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="534.33185" z="1219.62073"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="53498"/>
 		</Entity>
 		<Entity uid="10561">
 			<Template>gaia/tree/date_palm</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="455.71167" z="1167.33362"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="58465"/>
 		</Entity>
 		<Entity uid="10562">
 			<Template>gaia/tree/date_palm</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="411.94394" z="1200.99073"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="27000"/>
 		</Entity>
 		<Entity uid="10563">
 			<Template>gaia/tree/date_palm</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="407.44233" z="1208.6399"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="22645"/>
 		</Entity>
 		<Entity uid="10564">
 			<Template>gaia/tree/date_palm</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="399.08225" z="1214.68274"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="37000"/>
 		</Entity>
 		<Entity uid="10565">
 			<Template>gaia/tree/date_palm</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="461.57044" z="1335.44336"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="49310"/>
 		</Entity>
 		<Entity uid="10566">
 			<Template>gaia/tree/date_palm</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="467.42631" z="1331.39307"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="11840"/>
 		</Entity>
 		<Entity uid="10567">
 			<Template>gaia/tree/date_palm</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="490.83338" z="1353.47754"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="51079"/>
 		</Entity>
 		<Entity uid="10568">
 			<Template>gaia/tree/date_palm</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="499.73853" z="1367.04285"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="47197"/>
 		</Entity>
 		<Entity uid="10569">
 			<Template>gaia/tree/date_palm</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="516.79731" z="1382.3169"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="38309"/>
 		</Entity>
 		<Entity uid="10570">
 			<Template>gaia/tree/date_palm</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="517.88929" z="1390.88917"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="27051"/>
 		</Entity>
 		<Entity uid="10571">
 			<Template>gaia/tree/date_palm</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="522.03846" z="1387.64551"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="44393"/>
 		</Entity>
 		<Entity uid="10572">
 			<Template>gaia/tree/date_palm</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="525.94544" z="1392.45398"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="55883"/>
 		</Entity>
 		<Entity uid="10573">
 			<Template>gaia/tree/date_palm</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="524.13001" z="1424.45118"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="29160"/>
 		</Entity>
 		<Entity uid="10574">
 			<Template>gaia/tree/date_palm</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="530.08796" z="1413.20862"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="23141"/>
 		</Entity>
 		<Entity uid="10575">
 			<Template>gaia/tree/date_palm</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="529.35297" z="1402.86915"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="61320"/>
 		</Entity>
 		<Entity uid="10576">
 			<Template>gaia/tree/date_palm</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="535.17786" z="1404.00892"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="65463"/>
 		</Entity>
 		<Entity uid="10577">
 			<Template>gaia/tree/date_palm</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="534.92975" z="1393.20594"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="64972"/>
 		</Entity>
 		<Entity uid="10578">
 			<Template>gaia/tree/date_palm</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="540.70972" z="1401.30652"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="43134"/>
 		</Entity>
 		<Entity uid="10579">
 			<Template>gaia/tree/date_palm</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="545.4408" z="1401.45936"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="6473"/>
 		</Entity>
 		<Entity uid="10580">
 			<Template>gaia/tree/date_palm</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="549.64753" z="1405.64014"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="878"/>
 		</Entity>
 		<Entity uid="10581">
 			<Template>gaia/tree/date_palm</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="551.24195" z="1413.72876"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="37634"/>
 		</Entity>
 		<Entity uid="10582">
 			<Template>gaia/tree/date_palm</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="552.43287" z="1428.15442"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="17108"/>
 		</Entity>
 		<Entity uid="10583">
 			<Template>gaia/tree/date_palm</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="557.00684" z="1423.36988"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="44811"/>
 		</Entity>
 		<Entity uid="10584">
 			<Template>gaia/tree/date_palm</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="558.8968" z="1422.5536"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="55361"/>
 		</Entity>
 		<Entity uid="10585">
 			<Template>gaia/tree/date_palm</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="554.563" z="1412.36292"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="40601"/>
 		</Entity>
 		<Entity uid="10586">
 			<Template>gaia/tree/date_palm</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="560.8772" z="1418.07667"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="17452"/>
 		</Entity>
 		<Entity uid="10587">
 			<Template>gaia/tree/date_palm</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="563.97565" z="1420.27662"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="45447"/>
 		</Entity>
 		<Entity uid="10588">
 			<Template>gaia/tree/date_palm</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="564.82068" z="1424.63172"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="35083"/>
 		</Entity>
 		<Entity uid="10589">
 			<Template>gaia/tree/date_palm</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="569.3631" z="1432.14271"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="20114"/>
 		</Entity>
 		<Entity uid="10590">
 			<Template>gaia/tree/date_palm</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="573.84028" z="1434.02283"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="13616"/>
 		</Entity>
 		<Entity uid="10591">
 			<Template>gaia/tree/date_palm</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="576.26374" z="1435.74341"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="16593"/>
 		</Entity>
 		<Entity uid="10592">
 			<Template>gaia/tree/date_palm</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="298.78534" z="1255.69605"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="56713"/>
 		</Entity>
 		<Entity uid="10593">
 			<Template>gaia/tree/date_palm</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="302.7115" z="1247.96998"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="50051"/>
 		</Entity>
 		<Entity uid="10594">
 			<Template>gaia/tree/date_palm</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="267.91718" z="1212.46167"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="30197"/>
 		</Entity>
 		<Entity uid="10595">
 			<Template>gaia/tree/date_palm</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="265.22028" z="1222.063"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="52398"/>
 		</Entity>
 		<Entity uid="10596">
 			<Template>gaia/tree/date_palm</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="262.5752" z="1220.99402"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="59679"/>
@@ -18692,28 +18692,28 @@
 		</Entity>
 		<Entity uid="12325">
 			<Template>gaia/tree/poplar</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="870.10816" z="716.0345"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="42562"/>
 		</Entity>
 		<Entity uid="12326">
 			<Template>gaia/tree/poplar</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="882.97345" z="713.9828"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="33865"/>
 		</Entity>
 		<Entity uid="12327">
 			<Template>gaia/tree/poplar</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="650.85499" z="591.66437"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="1273"/>
 		</Entity>
 		<Entity uid="12328">
 			<Template>gaia/tree/poplar</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="697.56562" z="583.66504"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="38739"/>
@@ -18853,14 +18853,14 @@
 		</Entity>
 		<Entity uid="12348">
 			<Template>gaia/tree/poplar</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="643.37983" z="370.7906"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="32288"/>
 		</Entity>
 		<Entity uid="12349">
 			<Template>gaia/tree/poplar</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="650.70362" z="367.15296"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="58969"/>
@@ -20987,63 +20987,63 @@
 		</Entity>
 		<Entity uid="12663">
 			<Template>gaia/rock/desert_large</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="478.41947" z="913.70594"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="42764"/>
 		</Entity>
 		<Entity uid="12664">
 			<Template>gaia/rock/desert_large</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="476.62937" z="1237.11866"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="63557"/>
 		</Entity>
 		<Entity uid="12665">
 			<Template>gaia/rock/desert_large</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="526.40174" z="1367.92298"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="17135"/>
 		</Entity>
 		<Entity uid="12666">
 			<Template>gaia/ore/mediterranean_large</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="674.79578" z="1343.31446"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="61342"/>
 		</Entity>
 		<Entity uid="12667">
 			<Template>gaia/ore/mediterranean_large</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="919.99256" z="1201.00489"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="5362"/>
 		</Entity>
 		<Entity uid="12668">
 			<Template>gaia/ore/mediterranean_large</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="754.98005" z="971.97834"/>
 			<Orientation y="-2.59508"/>
 			<Actor seed="4256"/>
 		</Entity>
 		<Entity uid="12669">
 			<Template>gaia/ore/mediterranean_large</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="325.09073" z="969.64875"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="26391"/>
 		</Entity>
 		<Entity uid="12670">
 			<Template>gaia/ore/mediterranean_large</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="297.41138" z="1110.50037"/>
 			<Orientation y="-3.01366"/>
 			<Actor seed="44837"/>
 		</Entity>
 		<Entity uid="12671">
 			<Template>gaia/ore/mediterranean_large</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="336.32136" z="1372.68152"/>
 			<Orientation y="-2.77201"/>
 			<Actor seed="47072"/>
@@ -23796,98 +23796,98 @@
 		</Entity>
 		<Entity uid="13163">
 			<Template>gaia/fruit/fig</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="736.66486" z="998.03632"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="50306"/>
 		</Entity>
 		<Entity uid="13164">
 			<Template>gaia/fruit/fig</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="729.86396" z="1008.956"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="52665"/>
 		</Entity>
 		<Entity uid="13165">
 			<Template>gaia/fruit/fig</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="724.68836" z="1016.94623"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="512"/>
 		</Entity>
 		<Entity uid="13166">
 			<Template>gaia/fruit/fig</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="715.54548" z="1026.6438"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="1188"/>
 		</Entity>
 		<Entity uid="13167">
 			<Template>gaia/fruit/fig</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="705.53107" z="1036.97071"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="45446"/>
 		</Entity>
 		<Entity uid="13168">
 			<Template>gaia/fruit/fig</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="700.99732" z="1042.8888"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="12458"/>
 		</Entity>
 		<Entity uid="13169">
 			<Template>gaia/fruit/fig</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="730.85773" z="989.69471"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="6682"/>
 		</Entity>
 		<Entity uid="13170">
 			<Template>gaia/fruit/fig</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="729.92084" z="984.33051"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="1236"/>
 		</Entity>
 		<Entity uid="13171">
 			<Template>gaia/fruit/fig</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="687.65687" z="946.13953"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="11300"/>
 		</Entity>
 		<Entity uid="13172">
 			<Template>gaia/fruit/fig</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="698.64966" z="951.39228"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="16706"/>
 		</Entity>
 		<Entity uid="13173">
 			<Template>gaia/fruit/fig</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="632.35798" z="1000.09125"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="63955"/>
 		</Entity>
 		<Entity uid="13174">
 			<Template>gaia/fruit/date</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="635.21308" z="1029.9939"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="25718"/>
 		</Entity>
 		<Entity uid="13175">
 			<Template>gaia/fruit/date</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="621.21924" z="1001.53846"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="52988"/>
 		</Entity>
 		<Entity uid="13176">
 			<Template>gaia/fruit/date</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="617.87647" z="996.1391"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="37229"/>
@@ -24529,7 +24529,7 @@
 		</Entity>
 		<Entity uid="13293">
 			<Template>gaia/fruit/berry_05</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="456.37095" z="878.607"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="50369"/>
@@ -29540,378 +29540,378 @@
 		</Entity>
 		<Entity uid="14366">
 			<Template>gaia/tree/bush_tropic</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="710.73035" z="1066.97718"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="664"/>
 		</Entity>
 		<Entity uid="14367">
 			<Template>gaia/tree/bush_tropic</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="746.30304" z="1081.94324"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="11246"/>
 		</Entity>
 		<Entity uid="14368">
 			<Template>gaia/tree/bush_tropic</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="732.21827" z="1047.24512"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="15474"/>
 		</Entity>
 		<Entity uid="14369">
 			<Template>gaia/tree/bush_tropic</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="708.94672" z="1060.75098"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="1838"/>
 		</Entity>
 		<Entity uid="14370">
 			<Template>gaia/tree/bush_tropic</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="715.12317" z="1064.38953"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="5231"/>
 		</Entity>
 		<Entity uid="14371">
 			<Template>gaia/tree/bush_tropic</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="739.49488" z="1088.85865"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="26073"/>
 		</Entity>
 		<Entity uid="14372">
 			<Template>gaia/tree/bush_tropic</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="737.4131" z="1085.29139"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="64258"/>
 		</Entity>
 		<Entity uid="14373">
 			<Template>gaia/tree/bush_tropic</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="740.20484" z="1076.48292"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="21652"/>
 		</Entity>
 		<Entity uid="14374">
 			<Template>gaia/tree/bush_tropic</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="752.01026" z="1078.54651"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="22407"/>
 		</Entity>
 		<Entity uid="14375">
 			<Template>gaia/tree/bush_tropic</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="755.83063" z="1074.62085"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="7179"/>
 		</Entity>
 		<Entity uid="14376">
 			<Template>gaia/tree/bush_tropic</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="724.05488" z="1102.21265"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="21496"/>
 		</Entity>
 		<Entity uid="14377">
 			<Template>gaia/tree/bush_tropic</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="729.48798" z="1094.28064"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="60511"/>
 		</Entity>
 		<Entity uid="14378">
 			<Template>gaia/tree/bush_tropic</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="732.68635" z="1094.02393"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="22848"/>
 		</Entity>
 		<Entity uid="14379">
 			<Template>gaia/tree/bush_tropic</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="733.0157" z="1090.58216"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="10871"/>
 		</Entity>
 		<Entity uid="14380">
 			<Template>gaia/tree/bush_tropic</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="729.14441" z="1093.45752"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="9034"/>
 		</Entity>
 		<Entity uid="14381">
 			<Template>gaia/tree/bush_tropic</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="731.52906" z="1101.18824"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="3624"/>
 		</Entity>
 		<Entity uid="14382">
 			<Template>gaia/tree/bush_tropic</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="692.39161" z="1084.31446"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="26136"/>
 		</Entity>
 		<Entity uid="14383">
 			<Template>gaia/tree/bush_tropic</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="690.7021" z="1077.82911"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="245"/>
 		</Entity>
 		<Entity uid="14384">
 			<Template>gaia/tree/bush_tropic</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="696.39399" z="1077.73243"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="33466"/>
 		</Entity>
 		<Entity uid="14385">
 			<Template>gaia/tree/bush_tropic</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="694.87995" z="1080.71814"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="41799"/>
 		</Entity>
 		<Entity uid="14386">
 			<Template>gaia/tree/bush_tropic</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="688.47321" z="1081.24708"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="22754"/>
 		</Entity>
 		<Entity uid="14387">
 			<Template>gaia/tree/bush_tropic</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="685.89435" z="1089.6178"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="2205"/>
 		</Entity>
 		<Entity uid="14388">
 			<Template>gaia/tree/bush_tropic</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="703.1266" z="1072.04444"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="40729"/>
 		</Entity>
 		<Entity uid="14389">
 			<Template>gaia/tree/bush_tropic</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="705.42603" z="1071.4004"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="9449"/>
 		</Entity>
 		<Entity uid="14390">
 			<Template>gaia/tree/bush_tropic</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="703.87739" z="1065.73096"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="39207"/>
 		</Entity>
 		<Entity uid="14391">
 			<Template>gaia/tree/bush_tropic</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="740.70051" z="1038.54859"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="50586"/>
 		</Entity>
 		<Entity uid="14392">
 			<Template>gaia/tree/bush_tropic</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="737.58844" z="1032.15027"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="49745"/>
 		</Entity>
 		<Entity uid="14393">
 			<Template>gaia/tree/bush_tropic</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="766.79792" z="1064.8816"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="47199"/>
 		</Entity>
 		<Entity uid="14394">
 			<Template>gaia/tree/bush_tropic</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="707.24122" z="1117.188"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="20546"/>
 		</Entity>
 		<Entity uid="14395">
 			<Template>gaia/tree/bush_tropic</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="700.62397" z="1113.69556"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="10547"/>
 		</Entity>
 		<Entity uid="14396">
 			<Template>gaia/tree/bush_tropic</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="718.49585" z="1071.76307"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="30941"/>
 		</Entity>
 		<Entity uid="14397">
 			<Template>gaia/tree/bush_tropic</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="726.83661" z="1073.15992"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="54173"/>
 		</Entity>
 		<Entity uid="14398">
 			<Template>gaia/tree/bush_tropic</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="723.08338" z="1067.06824"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="47025"/>
 		</Entity>
 		<Entity uid="14399">
 			<Template>gaia/tree/bush_tropic</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="724.19867" z="1061.37916"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="43033"/>
 		</Entity>
 		<Entity uid="14400">
 			<Template>gaia/tree/bush_tropic</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="737.41755" z="1074.05726"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="15694"/>
 		</Entity>
 		<Entity uid="14401">
 			<Template>gaia/tree/bush_tropic</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="730.01874" z="1078.30848"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="21927"/>
 		</Entity>
 		<Entity uid="14402">
 			<Template>gaia/tree/bush_tropic</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="730.99567" z="1084.62818"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="33681"/>
 		</Entity>
 		<Entity uid="14403">
 			<Template>gaia/tree/bush_tropic</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="725.28803" z="1081.66834"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="23345"/>
 		</Entity>
 		<Entity uid="14404">
 			<Template>gaia/tree/bush_tropic</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="718.96717" z="1077.2118"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="61950"/>
 		</Entity>
 		<Entity uid="14405">
 			<Template>gaia/tree/bush_tropic</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="715.72761" z="1074.77442"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="31019"/>
 		</Entity>
 		<Entity uid="14406">
 			<Template>gaia/tree/bush_tropic</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="726.33997" z="1069.29249"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="48508"/>
 		</Entity>
 		<Entity uid="14407">
 			<Template>gaia/tree/bush_tropic</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="732.55079" z="1069.55298"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="9877"/>
 		</Entity>
 		<Entity uid="14408">
 			<Template>gaia/tree/bush_tropic</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="733.05384" z="1071.63001"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="51985"/>
 		</Entity>
 		<Entity uid="14409">
 			<Template>gaia/tree/bush_tropic</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="739.4391" z="1079.25635"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="42770"/>
 		</Entity>
 		<Entity uid="14410">
 			<Template>gaia/tree/bush_tropic</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="736.57306" z="1079.8755"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="25263"/>
 		</Entity>
 		<Entity uid="14411">
 			<Template>gaia/tree/bush_tropic</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="720.3202" z="1067.61072"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="39299"/>
 		</Entity>
 		<Entity uid="14412">
 			<Template>gaia/tree/bush_tropic</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="717.068" z="1068.89295"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="8929"/>
 		</Entity>
 		<Entity uid="14413">
 			<Template>gaia/tree/bush_tropic</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="713.15314" z="1071.04566"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="31699"/>
 		</Entity>
 		<Entity uid="14414">
 			<Template>gaia/tree/bush_tropic</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="720.18458" z="1060.1797"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="56049"/>
 		</Entity>
 		<Entity uid="14415">
 			<Template>gaia/tree/bush_tropic</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="714.24817" z="1059.85926"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="45006"/>
 		</Entity>
 		<Entity uid="14424">
 			<Template>gaia/tree/cypress_wild</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="815.20588" z="1091.34046"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="1257"/>
 		</Entity>
 		<Entity uid="14425">
 			<Template>gaia/tree/cypress_wild</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="815.21387" z="1095.34485"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="10280"/>
 		</Entity>
 		<Entity uid="14426">
 			<Template>gaia/tree/cypress_wild</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="812.43305" z="1091.6637"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="29984"/>
 		</Entity>
 		<Entity uid="14428">
 			<Template>gaia/tree/cypress_wild</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="806.67994" z="1091.82435"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="39185"/>

--- a/maps/skirmishes/alpine_stef.xml
+++ b/maps/skirmishes/alpine_stef.xml
@@ -15479,21 +15479,21 @@
 		</Entity>
 		<Entity uid="2489">
 			<Template>gaia/fish/generic</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="526.66626" z="314.28476"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="35726"/>
 		</Entity>
 		<Entity uid="2490">
 			<Template>gaia/fish/generic</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="338.62085" z="471.48816"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="55660"/>
 		</Entity>
 		<Entity uid="2491">
 			<Template>gaia/fish/generic</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="535.90088" z="461.10169"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="57897"/>
@@ -17593,217 +17593,217 @@
 		</Entity>
 		<Entity uid="2802">
 			<Template>gaia/tree/pine_w</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="400.12598" z="267.13059"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="49352"/>
 		</Entity>
 		<Entity uid="2803">
 			<Template>gaia/tree/pine_w</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="397.34235" z="268.68311"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="20138"/>
 		</Entity>
 		<Entity uid="2804">
 			<Template>gaia/tree/pine_w</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="400.75025" z="260.47443"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="54058"/>
 		</Entity>
 		<Entity uid="2805">
 			<Template>gaia/tree/pine_w</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="410.91953" z="266.26664"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="30912"/>
 		</Entity>
 		<Entity uid="2806">
 			<Template>gaia/tree/pine_w</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="407.17597" z="264.95508"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="5218"/>
 		</Entity>
 		<Entity uid="2807">
 			<Template>gaia/tree/pine_w</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="407.89628" z="271.93528"/>
 			<Orientation y="2.10425"/>
 			<Actor seed="16725"/>
 		</Entity>
 		<Entity uid="2808">
 			<Template>gaia/tree/pine_w</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="408.50388" z="272.95038"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="38422"/>
 		</Entity>
 		<Entity uid="2809">
 			<Template>gaia/tree/pine_w</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="403.97101" z="276.0601"/>
 			<Orientation y="-1.41628"/>
 			<Actor seed="47074"/>
 		</Entity>
 		<Entity uid="2810">
 			<Template>gaia/tree/pine_w</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="395.46692" z="278.55094"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="49776"/>
 		</Entity>
 		<Entity uid="2811">
 			<Template>gaia/tree/pine_w</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="394.44681" z="284.23411"/>
 			<Orientation y="0.18424"/>
 			<Actor seed="12521"/>
 		</Entity>
 		<Entity uid="2812">
 			<Template>gaia/tree/pine_w</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="396.5041" z="287.58664"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="18174"/>
 		</Entity>
 		<Entity uid="2813">
 			<Template>gaia/tree/pine_w</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="399.07511" z="278.09412"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="37663"/>
 		</Entity>
 		<Entity uid="2814">
 			<Template>gaia/tree/pine_w</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="400.32547" z="280.97141"/>
 			<Orientation y="0.5795"/>
 			<Actor seed="41224"/>
 		</Entity>
 		<Entity uid="2815">
 			<Template>gaia/tree/pine_w</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="403.95273" z="284.9495"/>
 			<Orientation y="0.05076"/>
 			<Actor seed="18852"/>
 		</Entity>
 		<Entity uid="2816">
 			<Template>gaia/tree/pine_w</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="404.65644" z="291.09174"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="5991"/>
 		</Entity>
 		<Entity uid="2817">
 			<Template>gaia/tree/pine_w</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="405.10505" z="295.2895"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="42956"/>
 		</Entity>
 		<Entity uid="2818">
 			<Template>gaia/tree/pine_w</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="402.6092" z="298.1966"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="52307"/>
 		</Entity>
 		<Entity uid="2819">
 			<Template>gaia/tree/pine_w</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="399.91178" z="299.40485"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="12450"/>
 		</Entity>
 		<Entity uid="2820">
 			<Template>gaia/tree/pine_w</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="409.35328" z="294.2566"/>
 			<Orientation y="2.0919"/>
 			<Actor seed="50880"/>
 		</Entity>
 		<Entity uid="2821">
 			<Template>gaia/tree/pine_w</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="417.75251" z="290.48111"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="38956"/>
 		</Entity>
 		<Entity uid="2822">
 			<Template>gaia/tree/pine_w</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="419.63526" z="282.35694"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="35848"/>
 		</Entity>
 		<Entity uid="2823">
 			<Template>gaia/tree/pine_w</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="421.69382" z="277.88187"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="43248"/>
 		</Entity>
 		<Entity uid="2824">
 			<Template>gaia/tree/pine_w</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="423.57914" z="275.09891"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="32282"/>
 		</Entity>
 		<Entity uid="2825">
 			<Template>gaia/tree/pine_w</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="425.07151" z="273.99286"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="2647"/>
 		</Entity>
 		<Entity uid="2826">
 			<Template>gaia/tree/pine_w</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="426.83921" z="274.11615"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="64194"/>
 		</Entity>
 		<Entity uid="2827">
 			<Template>gaia/tree/pine_w</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="431.77814" z="277.93674"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="55545"/>
 		</Entity>
 		<Entity uid="2828">
 			<Template>gaia/tree/pine_w</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="468.83658" z="362.95191"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="57397"/>
 		</Entity>
 		<Entity uid="2829">
 			<Template>gaia/tree/pine_w</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="447.53864" z="361.63642"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="32722"/>
 		</Entity>
 		<Entity uid="2830">
 			<Template>gaia/tree/pine_w</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="479.28058" z="384.86014"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="27165"/>
 		</Entity>
 		<Entity uid="2831">
 			<Template>gaia/tree/pine_w</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="462.2952" z="363.19178"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="30838"/>
 		</Entity>
 		<Entity uid="2832">
 			<Template>gaia/tree/pine_w</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="493.65827" z="379.4192"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="59064"/>

--- a/maps/skirmishes/battle_of_vikingland.xml
+++ b/maps/skirmishes/battle_of_vikingland.xml
@@ -8925,896 +8925,896 @@
 		</Entity>
 		<Entity uid="1538">
 			<Template>gaia/fruit/berry_01</Template>
-			<Player>8</Player>
+			<Player>0</Player>
 			<Position x="1330.61463" z="987.67286"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="45586"/>
 		</Entity>
 		<Entity uid="1539">
 			<Template>gaia/fruit/berry_01</Template>
-			<Player>8</Player>
+			<Player>0</Player>
 			<Position x="1333.1847" z="991.43989"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="51632"/>
 		</Entity>
 		<Entity uid="1540">
 			<Template>gaia/fruit/berry_01</Template>
-			<Player>8</Player>
+			<Player>0</Player>
 			<Position x="1334.85718" z="996.11823"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="26722"/>
 		</Entity>
 		<Entity uid="1541">
 			<Template>gaia/fruit/berry_01</Template>
-			<Player>8</Player>
+			<Player>0</Player>
 			<Position x="1329.83875" z="998.11963"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="37768"/>
 		</Entity>
 		<Entity uid="1542">
 			<Template>gaia/fruit/berry_01</Template>
-			<Player>8</Player>
+			<Player>0</Player>
 			<Position x="1327.26258" z="993.93396"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="21704"/>
 		</Entity>
 		<Entity uid="1543">
 			<Template>gaia/fruit/berry_01</Template>
-			<Player>8</Player>
+			<Player>0</Player>
 			<Position x="1324.90857" z="989.60633"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="49114"/>
 		</Entity>
 		<Entity uid="1544">
 			<Template>gaia/fruit/berry_01</Template>
-			<Player>8</Player>
+			<Player>0</Player>
 			<Position x="1350.50977" z="562.10016"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="36244"/>
 		</Entity>
 		<Entity uid="1545">
 			<Template>gaia/fruit/berry_01</Template>
-			<Player>8</Player>
+			<Player>0</Player>
 			<Position x="1353.72925" z="558.8368"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="9582"/>
 		</Entity>
 		<Entity uid="1546">
 			<Template>gaia/fruit/berry_01</Template>
-			<Player>8</Player>
+			<Player>0</Player>
 			<Position x="1346.54822" z="559.69715"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="20770"/>
 		</Entity>
 		<Entity uid="1547">
 			<Template>gaia/fruit/berry_01</Template>
-			<Player>8</Player>
+			<Player>0</Player>
 			<Position x="1350.21949" z="555.06629"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="37152"/>
 		</Entity>
 		<Entity uid="1548">
 			<Template>gaia/fruit/berry_01</Template>
-			<Player>8</Player>
+			<Player>0</Player>
 			<Position x="1343.32288" z="556.4585"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="12600"/>
 		</Entity>
 		<Entity uid="1549">
 			<Template>gaia/fruit/berry_01</Template>
-			<Player>8</Player>
+			<Player>0</Player>
 			<Position x="1346.44861" z="551.65314"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="46240"/>
 		</Entity>
 		<Entity uid="1550">
 			<Template>gaia/fruit/berry_01</Template>
-			<Player>8</Player>
+			<Player>0</Player>
 			<Position x="1018.36164" z="218.66468"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="62386"/>
 		</Entity>
 		<Entity uid="1551">
 			<Template>gaia/fruit/berry_01</Template>
-			<Player>8</Player>
+			<Player>0</Player>
 			<Position x="1013.76246" z="215.63032"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="32124"/>
 		</Entity>
 		<Entity uid="1552">
 			<Template>gaia/fruit/berry_01</Template>
-			<Player>8</Player>
+			<Player>0</Player>
 			<Position x="1010.58136" z="213.20435"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="41602"/>
 		</Entity>
 		<Entity uid="1553">
 			<Template>gaia/fruit/berry_01</Template>
-			<Player>8</Player>
+			<Player>0</Player>
 			<Position x="1014.36408" z="209.1402"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="42532"/>
 		</Entity>
 		<Entity uid="1554">
 			<Template>gaia/fruit/berry_01</Template>
-			<Player>8</Player>
+			<Player>0</Player>
 			<Position x="1017.61689" z="212.2292"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="38282"/>
 		</Entity>
 		<Entity uid="1555">
 			<Template>gaia/fruit/berry_01</Template>
-			<Player>8</Player>
+			<Player>0</Player>
 			<Position x="1021.76307" z="215.29004"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="24912"/>
 		</Entity>
 		<Entity uid="1556">
 			<Template>gaia/fruit/berry_01</Template>
-			<Player>8</Player>
+			<Player>0</Player>
 			<Position x="631.43409" z="252.08783"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="5490"/>
 		</Entity>
 		<Entity uid="1557">
 			<Template>gaia/fruit/berry_01</Template>
-			<Player>8</Player>
+			<Player>0</Player>
 			<Position x="627.55835" z="255.89792"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="33428"/>
 		</Entity>
 		<Entity uid="1558">
 			<Template>gaia/fruit/berry_01</Template>
-			<Player>8</Player>
+			<Player>0</Player>
 			<Position x="635.14954" z="256.24543"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="44786"/>
 		</Entity>
 		<Entity uid="1559">
 			<Template>gaia/fruit/berry_01</Template>
-			<Player>8</Player>
+			<Player>0</Player>
 			<Position x="630.8152" z="259.15528"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="7528"/>
 		</Entity>
 		<Entity uid="1560">
 			<Template>gaia/fruit/berry_01</Template>
-			<Player>8</Player>
+			<Player>0</Player>
 			<Position x="638.39747" z="259.5037"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="35518"/>
 		</Entity>
 		<Entity uid="1561">
 			<Template>gaia/fruit/berry_01</Template>
-			<Player>8</Player>
+			<Player>0</Player>
 			<Position x="635.13495" z="262.74585"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="56948"/>
 		</Entity>
 		<Entity uid="1562">
 			<Template>gaia/fruit/berry_01</Template>
-			<Player>8</Player>
+			<Player>0</Player>
 			<Position x="275.23676" z="512.76905"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="16006"/>
 		</Entity>
 		<Entity uid="1563">
 			<Template>gaia/fruit/berry_01</Template>
-			<Player>8</Player>
+			<Player>0</Player>
 			<Position x="278.81678" z="518.02186"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="394"/>
 		</Entity>
 		<Entity uid="1564">
 			<Template>gaia/fruit/berry_01</Template>
-			<Player>8</Player>
+			<Player>0</Player>
 			<Position x="282.03473" z="521.69355"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="45110"/>
 		</Entity>
 		<Entity uid="1565">
 			<Template>gaia/fruit/berry_01</Template>
-			<Player>8</Player>
+			<Player>0</Player>
 			<Position x="285.09614" z="517.67591"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="22766"/>
 		</Entity>
 		<Entity uid="1566">
 			<Template>gaia/fruit/berry_01</Template>
-			<Player>8</Player>
+			<Player>0</Player>
 			<Position x="282.32911" z="514.88526"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="60648"/>
 		</Entity>
 		<Entity uid="1567">
 			<Template>gaia/fruit/berry_01</Template>
-			<Player>8</Player>
+			<Player>0</Player>
 			<Position x="279.1117" z="510.77918"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="376"/>
 		</Entity>
 		<Entity uid="1568">
 			<Template>gaia/fruit/berry_01</Template>
-			<Player>8</Player>
+			<Player>0</Player>
 			<Position x="235.65851" z="938.28602"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="25012"/>
 		</Entity>
 		<Entity uid="1569">
 			<Template>gaia/fruit/berry_01</Template>
-			<Player>8</Player>
+			<Player>0</Player>
 			<Position x="239.91926" z="934.92505"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="47392"/>
 		</Entity>
 		<Entity uid="1570">
 			<Template>gaia/fruit/berry_01</Template>
-			<Player>8</Player>
+			<Player>0</Player>
 			<Position x="242.29947" z="939.07935"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="54494"/>
 		</Entity>
 		<Entity uid="1571">
 			<Template>gaia/fruit/berry_01</Template>
-			<Player>8</Player>
+			<Player>0</Player>
 			<Position x="238.46094" z="941.53846"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="64638"/>
 		</Entity>
 		<Entity uid="1572">
 			<Template>gaia/fruit/berry_01</Template>
-			<Player>8</Player>
+			<Player>0</Player>
 			<Position x="241.0983" z="945.32569"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="62070"/>
 		</Entity>
 		<Entity uid="1573">
 			<Template>gaia/fruit/berry_01</Template>
-			<Player>8</Player>
+			<Player>0</Player>
 			<Position x="245.64768" z="942.95032"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="45536"/>
 		</Entity>
 		<Entity uid="1574">
 			<Template>gaia/fruit/berry_01</Template>
-			<Player>8</Player>
+			<Player>0</Player>
 			<Position x="532.9087" z="1290.39942"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="22526"/>
 		</Entity>
 		<Entity uid="1575">
 			<Template>gaia/fruit/berry_01</Template>
-			<Player>8</Player>
+			<Player>0</Player>
 			<Position x="536.46875" z="1294.48975"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="57202"/>
 		</Entity>
 		<Entity uid="1576">
 			<Template>gaia/fruit/berry_01</Template>
-			<Player>8</Player>
+			<Player>0</Player>
 			<Position x="540.39826" z="1298.84595"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="59158"/>
 		</Entity>
 		<Entity uid="1577">
 			<Template>gaia/fruit/berry_01</Template>
-			<Player>8</Player>
+			<Player>0</Player>
 			<Position x="542.94068" z="1295.91016"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="21516"/>
 		</Entity>
 		<Entity uid="1578">
 			<Template>gaia/fruit/berry_01</Template>
-			<Player>8</Player>
+			<Player>0</Player>
 			<Position x="540.31067" z="1291.82093"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="59356"/>
 		</Entity>
 		<Entity uid="1579">
 			<Template>gaia/fruit/berry_01</Template>
-			<Player>8</Player>
+			<Player>0</Player>
 			<Position x="537.41584" z="1288.0912"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="59714"/>
 		</Entity>
 		<Entity uid="1580">
 			<Template>gaia/fruit/berry_01</Template>
-			<Player>8</Player>
+			<Player>0</Player>
 			<Position x="1029.8932" z="1277.11951"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="18408"/>
 		</Entity>
 		<Entity uid="1581">
 			<Template>gaia/fruit/berry_01</Template>
-			<Player>8</Player>
+			<Player>0</Player>
 			<Position x="1025.77332" z="1273.7588"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="46918"/>
 		</Entity>
 		<Entity uid="1582">
 			<Template>gaia/fruit/berry_01</Template>
-			<Player>8</Player>
+			<Player>0</Player>
 			<Position x="1022.29853" z="1271.12378"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="11174"/>
 		</Entity>
 		<Entity uid="1583">
 			<Template>gaia/fruit/berry_01</Template>
-			<Player>8</Player>
+			<Player>0</Player>
 			<Position x="1026.02125" z="1267.33863"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="55808"/>
 		</Entity>
 		<Entity uid="1584">
 			<Template>gaia/fruit/berry_01</Template>
-			<Player>8</Player>
+			<Player>0</Player>
 			<Position x="1030.03418" z="1271.02552"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="13282"/>
 		</Entity>
 		<Entity uid="1585">
 			<Template>gaia/fruit/berry_01</Template>
-			<Player>8</Player>
+			<Player>0</Player>
 			<Position x="1033.30103" z="1273.9469"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="57670"/>
 		</Entity>
 		<Entity uid="1586">
 			<Template>gaia/rock/alpine_large</Template>
-			<Player>8</Player>
+			<Player>0</Player>
 			<Position x="1285.32374" z="964.69794"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="21594"/>
 		</Entity>
 		<Entity uid="1587">
 			<Template>gaia/rock/alpine_large</Template>
-			<Player>8</Player>
+			<Player>0</Player>
 			<Position x="1248.86109" z="596.2544"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="56330"/>
 		</Entity>
 		<Entity uid="1588">
 			<Template>gaia/rock/alpine_large</Template>
-			<Player>8</Player>
+			<Player>0</Player>
 			<Position x="933.98371" z="314.89335"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="29598"/>
 		</Entity>
 		<Entity uid="1589">
 			<Template>gaia/rock/alpine_large</Template>
-			<Player>8</Player>
+			<Player>0</Player>
 			<Position x="573.08301" z="371.55726"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="41302"/>
 		</Entity>
 		<Entity uid="1590">
 			<Template>gaia/rock/alpine_large</Template>
-			<Player>8</Player>
+			<Player>0</Player>
 			<Position x="260.71387" z="615.24201"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="14774"/>
 		</Entity>
 		<Entity uid="1591">
 			<Template>gaia/rock/alpine_large</Template>
-			<Player>8</Player>
+			<Player>0</Player>
 			<Position x="292.81061" z="980.18714"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="36698"/>
 		</Entity>
 		<Entity uid="1592">
 			<Template>gaia/rock/alpine_large</Template>
-			<Player>8</Player>
+			<Player>0</Player>
 			<Position x="563.46058" z="1277.64917"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="10244"/>
 		</Entity>
 		<Entity uid="1593">
 			<Template>gaia/rock/alpine_large</Template>
-			<Player>8</Player>
+			<Player>0</Player>
 			<Position x="962.64258" z="1193.17469"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="12202"/>
 		</Entity>
 		<Entity uid="1594">
 			<Template>gaia/rock/alpine_large</Template>
-			<Player>8</Player>
+			<Player>0</Player>
 			<Position x="774.50037" z="512.60584"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="18604"/>
 		</Entity>
 		<Entity uid="1595">
 			<Template>gaia/rock/alpine_large</Template>
-			<Player>8</Player>
+			<Player>0</Player>
 			<Position x="979.30036" z="609.172"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="65318"/>
 		</Entity>
 		<Entity uid="1596">
 			<Template>gaia/rock/alpine_large</Template>
-			<Player>8</Player>
+			<Player>0</Player>
 			<Position x="1091.65955" z="809.08375"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="41750"/>
 		</Entity>
 		<Entity uid="1597">
 			<Template>gaia/rock/alpine_large</Template>
-			<Player>8</Player>
+			<Player>0</Player>
 			<Position x="959.90253" z="987.1963"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="32148"/>
 		</Entity>
 		<Entity uid="1598">
 			<Template>gaia/rock/alpine_large</Template>
-			<Player>8</Player>
+			<Player>0</Player>
 			<Position x="756.49622" z="1116.3971"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="50708"/>
 		</Entity>
 		<Entity uid="1599">
 			<Template>gaia/rock/alpine_large</Template>
-			<Player>8</Player>
+			<Player>0</Player>
 			<Position x="575.16541" z="1008.17585"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="25608"/>
 		</Entity>
 		<Entity uid="1600">
 			<Template>gaia/rock/alpine_large</Template>
-			<Player>8</Player>
+			<Player>0</Player>
 			<Position x="465.14081" z="827.99585"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="42406"/>
 		</Entity>
 		<Entity uid="1601">
 			<Template>gaia/rock/alpine_large</Template>
-			<Player>8</Player>
+			<Player>0</Player>
 			<Position x="612.87024" z="649.0951"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="35006"/>
 		</Entity>
 		<Entity uid="1602">
 			<Template>gaia/rock/alpine_large</Template>
-			<Player>8</Player>
+			<Player>0</Player>
 			<Position x="836.73444" z="832.4773"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="30858"/>
 		</Entity>
 		<Entity uid="1603">
 			<Template>gaia/rock/alpine_large</Template>
-			<Player>8</Player>
+			<Player>0</Player>
 			<Position x="802.5337" z="861.74781"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="43848"/>
 		</Entity>
 		<Entity uid="1604">
 			<Template>gaia/rock/alpine_large</Template>
-			<Player>8</Player>
+			<Player>0</Player>
 			<Position x="755.29566" z="855.28907"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="9344"/>
 		</Entity>
 		<Entity uid="1605">
 			<Template>gaia/rock/alpine_large</Template>
-			<Player>8</Player>
+			<Player>0</Player>
 			<Position x="836.24732" z="784.93262"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="48356"/>
 		</Entity>
 		<Entity uid="1606">
 			<Template>gaia/rock/alpine_large</Template>
-			<Player>8</Player>
+			<Player>0</Player>
 			<Position x="783.64039" z="762.68384"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="48764"/>
 		</Entity>
 		<Entity uid="1607">
 			<Template>gaia/rock/alpine_large</Template>
-			<Player>8</Player>
+			<Player>0</Player>
 			<Position x="734.35541" z="819.76606"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="21698"/>
 		</Entity>
 		<Entity uid="1608">
 			<Template>gaia/rock/alpine_large</Template>
-			<Player>8</Player>
+			<Player>0</Player>
 			<Position x="741.38801" z="782.58814"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="20144"/>
 		</Entity>
 		<Entity uid="1609">
 			<Template>gaia/ore/alpine_small</Template>
-			<Player>8</Player>
+			<Player>0</Player>
 			<Position x="811.95289" z="767.3531"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="1706"/>
 		</Entity>
 		<Entity uid="1610">
 			<Template>gaia/ore/alpine_small</Template>
-			<Player>8</Player>
+			<Player>0</Player>
 			<Position x="761.05866" z="772.26563"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="10570"/>
 		</Entity>
 		<Entity uid="1611">
 			<Template>gaia/ore/alpine_small</Template>
-			<Player>8</Player>
+			<Player>0</Player>
 			<Position x="736.97614" z="803.58631"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="2644"/>
 		</Entity>
 		<Entity uid="1612">
 			<Template>gaia/ore/alpine_small</Template>
-			<Player>8</Player>
+			<Player>0</Player>
 			<Position x="745.37323" z="837.7425"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="24796"/>
 		</Entity>
 		<Entity uid="1613">
 			<Template>gaia/ore/alpine_small</Template>
-			<Player>8</Player>
+			<Player>0</Player>
 			<Position x="783.05787" z="866.1283"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="29496"/>
 		</Entity>
 		<Entity uid="1614">
 			<Template>gaia/ore/alpine_small</Template>
-			<Player>8</Player>
+			<Player>0</Player>
 			<Position x="823.62208" z="853.07032"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="29088"/>
 		</Entity>
 		<Entity uid="1615">
 			<Template>gaia/ore/alpine_small</Template>
-			<Player>8</Player>
+			<Player>0</Player>
 			<Position x="844.02302" z="807.13501"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="61394"/>
 		</Entity>
 		<Entity uid="1616">
 			<Template>gaia/ore/alpine_small</Template>
-			<Player>8</Player>
+			<Player>0</Player>
 			<Position x="893.6341" z="764.87684"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="15198"/>
 		</Entity>
 		<Entity uid="1617">
 			<Template>gaia/ore/alpine_small</Template>
-			<Player>8</Player>
+			<Player>0</Player>
 			<Position x="895.11097" z="783.49982"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="61230"/>
 		</Entity>
 		<Entity uid="1618">
 			<Template>gaia/ore/alpine_small</Template>
-			<Player>8</Player>
+			<Player>0</Player>
 			<Position x="862.64588" z="694.01783"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="54730"/>
 		</Entity>
 		<Entity uid="1619">
 			<Template>gaia/ore/alpine_small</Template>
-			<Player>8</Player>
+			<Player>0</Player>
 			<Position x="845.64533" z="690.4209"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="19382"/>
 		</Entity>
 		<Entity uid="1620">
 			<Template>gaia/ore/alpine_small</Template>
-			<Player>8</Player>
+			<Player>0</Player>
 			<Position x="773.57435" z="717.50019"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="23826"/>
 		</Entity>
 		<Entity uid="1621">
 			<Template>gaia/ore/alpine_small</Template>
-			<Player>8</Player>
+			<Player>0</Player>
 			<Position x="765.59235" z="726.1424"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="32384"/>
 		</Entity>
 		<Entity uid="1622">
 			<Template>gaia/ore/alpine_small</Template>
-			<Player>8</Player>
+			<Player>0</Player>
 			<Position x="711.69397" z="789.7256"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="36102"/>
 		</Entity>
 		<Entity uid="1623">
 			<Template>gaia/ore/alpine_small</Template>
-			<Player>8</Player>
+			<Player>0</Player>
 			<Position x="716.2923" z="776.89417"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="12002"/>
 		</Entity>
 		<Entity uid="1624">
 			<Template>gaia/ore/alpine_small</Template>
-			<Player>8</Player>
+			<Player>0</Player>
 			<Position x="674.07453" z="895.20923"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="61278"/>
 		</Entity>
 		<Entity uid="1625">
 			<Template>gaia/ore/alpine_small</Template>
-			<Player>8</Player>
+			<Player>0</Player>
 			<Position x="675.69764" z="909.74585"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="4252"/>
 		</Entity>
 		<Entity uid="1626">
 			<Template>gaia/ore/alpine_small</Template>
-			<Player>8</Player>
+			<Player>0</Player>
 			<Position x="699.33002" z="968.38434"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="1584"/>
 		</Entity>
 		<Entity uid="1627">
 			<Template>gaia/ore/alpine_small</Template>
-			<Player>8</Player>
+			<Player>0</Player>
 			<Position x="709.20051" z="973.24708"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="5488"/>
 		</Entity>
 		<Entity uid="1628">
 			<Template>gaia/ore/alpine_small</Template>
-			<Player>8</Player>
+			<Player>0</Player>
 			<Position x="794.05225" z="951.53614"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="42026"/>
 		</Entity>
 		<Entity uid="1629">
 			<Template>gaia/ore/alpine_small</Template>
-			<Player>8</Player>
+			<Player>0</Player>
 			<Position x="791.57001" z="943.90857"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="40302"/>
 		</Entity>
 		<Entity uid="1630">
 			<Template>gaia/ore/alpine_small</Template>
-			<Player>8</Player>
+			<Player>0</Player>
 			<Position x="809.31543" z="933.58497"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="45218"/>
 		</Entity>
 		<Entity uid="1631">
 			<Template>gaia/ore/alpine_small</Template>
-			<Player>8</Player>
+			<Player>0</Player>
 			<Position x="791.6056" z="939.07703"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="11232"/>
 		</Entity>
 		<Entity uid="1632">
 			<Template>gaia/ore/alpine_small</Template>
-			<Player>8</Player>
+			<Player>0</Player>
 			<Position x="902.24073" z="861.93476"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="1538"/>
 		</Entity>
 		<Entity uid="1633">
 			<Template>gaia/ore/alpine_small</Template>
-			<Player>8</Player>
+			<Player>0</Player>
 			<Position x="909.4001" z="845.72382"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="54504"/>
 		</Entity>
 		<Entity uid="1634">
 			<Template>gaia/ore/alpine_small</Template>
-			<Player>8</Player>
+			<Player>0</Player>
 			<Position x="1284.20105" z="651.03974"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="21706"/>
 		</Entity>
 		<Entity uid="1635">
 			<Template>gaia/ore/alpine_small</Template>
-			<Player>8</Player>
+			<Player>0</Player>
 			<Position x="1276.36561" z="648.58051"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="10504"/>
 		</Entity>
 		<Entity uid="1636">
 			<Template>gaia/ore/alpine_small</Template>
-			<Player>8</Player>
+			<Player>0</Player>
 			<Position x="998.2339" z="332.87085"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="45668"/>
 		</Entity>
 		<Entity uid="1637">
 			<Template>gaia/ore/alpine_small</Template>
-			<Player>8</Player>
+			<Player>0</Player>
 			<Position x="999.28681" z="325.8871"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="49646"/>
 		</Entity>
 		<Entity uid="1638">
 			<Template>gaia/ore/alpine_small</Template>
-			<Player>8</Player>
+			<Player>0</Player>
 			<Position x="656.00794" z="343.75107"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="55000"/>
 		</Entity>
 		<Entity uid="1639">
 			<Template>gaia/ore/alpine_small</Template>
-			<Player>8</Player>
+			<Player>0</Player>
 			<Position x="657.16065" z="335.64838"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="31334"/>
 		</Entity>
 		<Entity uid="1640">
 			<Template>gaia/ore/alpine_small</Template>
-			<Player>8</Player>
+			<Player>0</Player>
 			<Position x="336.36063" z="564.4903"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="25134"/>
 		</Entity>
 		<Entity uid="1641">
 			<Template>gaia/ore/alpine_small</Template>
-			<Player>8</Player>
+			<Player>0</Player>
 			<Position x="335.15482" z="554.87031"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="18268"/>
 		</Entity>
 		<Entity uid="1642">
 			<Template>gaia/ore/alpine_small</Template>
-			<Player>8</Player>
+			<Player>0</Player>
 			<Position x="283.60969" z="897.15326"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="1702"/>
 		</Entity>
 		<Entity uid="1643">
 			<Template>gaia/ore/alpine_small</Template>
-			<Player>8</Player>
+			<Player>0</Player>
 			<Position x="276.28376" z="897.07306"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="12088"/>
 		</Entity>
 		<Entity uid="1644">
 			<Template>gaia/ore/alpine_small</Template>
-			<Player>8</Player>
+			<Player>0</Player>
 			<Position x="510.47785" z="1226.40101"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="59786"/>
 		</Entity>
 		<Entity uid="1645">
 			<Template>gaia/ore/alpine_small</Template>
-			<Player>8</Player>
+			<Player>0</Player>
 			<Position x="518.8155" z="1222.29078"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="26716"/>
 		</Entity>
 		<Entity uid="1646">
 			<Template>gaia/ore/alpine_small</Template>
-			<Player>8</Player>
+			<Player>0</Player>
 			<Position x="915.91205" z="1224.42823"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="34036"/>
 		</Entity>
 		<Entity uid="1647">
 			<Template>gaia/ore/alpine_small</Template>
-			<Player>8</Player>
+			<Player>0</Player>
 			<Position x="915.95032" z="1234.46631"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="64730"/>
 		</Entity>
 		<Entity uid="1648">
 			<Template>gaia/ore/alpine_small</Template>
-			<Player>8</Player>
+			<Player>0</Player>
 			<Position x="1232.77125" z="1023.1438"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="57728"/>
 		</Entity>
 		<Entity uid="1649">
 			<Template>gaia/ore/alpine_small</Template>
-			<Player>8</Player>
+			<Player>0</Player>
 			<Position x="1236.89112" z="1030.05542"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="44650"/>
 		</Entity>
 		<Entity uid="1650">
 			<Template>gaia/ore/alpine_small</Template>
-			<Player>8</Player>
+			<Player>0</Player>
 			<Position x="1107.38733" z="756.26478"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="14198"/>
 		</Entity>
 		<Entity uid="1651">
 			<Template>gaia/ore/alpine_small</Template>
-			<Player>8</Player>
+			<Player>0</Player>
 			<Position x="1110.9452" z="879.63508"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="11220"/>
 		</Entity>
 		<Entity uid="1652">
 			<Template>gaia/ore/alpine_small</Template>
-			<Player>8</Player>
+			<Player>0</Player>
 			<Position x="1028.52576" z="981.44459"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="916"/>
 		</Entity>
 		<Entity uid="1653">
 			<Template>gaia/ore/alpine_small</Template>
-			<Player>8</Player>
+			<Player>0</Player>
 			<Position x="926.58936" z="1053.71143"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="45986"/>
 		</Entity>
 		<Entity uid="1654">
 			<Template>gaia/ore/alpine_small</Template>
-			<Player>8</Player>
+			<Player>0</Player>
 			<Position x="863.33313" z="1144.98877"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="31732"/>
 		</Entity>
 		<Entity uid="1655">
 			<Template>gaia/ore/alpine_small</Template>
-			<Player>8</Player>
+			<Player>0</Player>
 			<Position x="720.85718" z="1128.15333"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="40554"/>
 		</Entity>
 		<Entity uid="1656">
 			<Template>gaia/ore/alpine_small</Template>
-			<Player>8</Player>
+			<Player>0</Player>
 			<Position x="560.30561" z="1127.8407"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="13858"/>
 		</Entity>
 		<Entity uid="1657">
 			<Template>gaia/ore/alpine_small</Template>
-			<Player>8</Player>
+			<Player>0</Player>
 			<Position x="457.38999" z="974.72413"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="40330"/>
 		</Entity>
 		<Entity uid="1658">
 			<Template>gaia/ore/alpine_small</Template>
-			<Player>8</Player>
+			<Player>0</Player>
 			<Position x="394.50766" z="886.09217"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="55290"/>
 		</Entity>
 		<Entity uid="1659">
 			<Template>gaia/ore/alpine_small</Template>
-			<Player>8</Player>
+			<Player>0</Player>
 			<Position x="436.12034" z="758.08204"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="24984"/>
 		</Entity>
 		<Entity uid="1660">
 			<Template>gaia/ore/alpine_small</Template>
-			<Player>8</Player>
+			<Player>0</Player>
 			<Position x="524.07911" z="652.41028"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="63824"/>
 		</Entity>
 		<Entity uid="1661">
 			<Template>gaia/ore/alpine_small</Template>
-			<Player>8</Player>
+			<Player>0</Player>
 			<Position x="605.96015" z="577.86347"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="30300"/>
 		</Entity>
 		<Entity uid="1662">
 			<Template>gaia/ore/alpine_small</Template>
-			<Player>8</Player>
+			<Player>0</Player>
 			<Position x="705.50757" z="481.6146"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="3324"/>
 		</Entity>
 		<Entity uid="1663">
 			<Template>gaia/ore/alpine_small</Template>
-			<Player>8</Player>
+			<Player>0</Player>
 			<Position x="800.07911" z="494.00412"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="4262"/>
 		</Entity>
 		<Entity uid="1664">
 			<Template>gaia/ore/alpine_small</Template>
-			<Player>8</Player>
+			<Player>0</Player>
 			<Position x="974.57294" z="456.50886"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="23656"/>
 		</Entity>
 		<Entity uid="1665">
 			<Template>gaia/ore/alpine_small</Template>
-			<Player>8</Player>
+			<Player>0</Player>
 			<Position x="1018.78132" z="611.67396"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="60620"/>

--- a/maps/skirmishes/caribbean_island_6p.xml
+++ b/maps/skirmishes/caribbean_island_6p.xml
@@ -4425,7 +4425,7 @@
 		</Entity>
 		<Entity uid="632">
 			<Template>gaia/fruit/fig</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="526.47907" z="550.84418"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="35397"/>
@@ -4446,7 +4446,7 @@
 		</Entity>
 		<Entity uid="635">
 			<Template>gaia/fruit/fig</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="480.56116" z="650.97864"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="63042"/>
@@ -4621,7 +4621,7 @@
 		</Entity>
 		<Entity uid="660">
 			<Template>gaia/tree/medit_fan_palm</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="509.6396" z="621.72114"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="48529"/>
@@ -5636,7 +5636,7 @@
 		</Entity>
 		<Entity uid="805">
 			<Template>gaia/tree/date_palm</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="547.61963" z="723.01148"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="44920"/>
@@ -5748,7 +5748,7 @@
 		</Entity>
 		<Entity uid="821">
 			<Template>gaia/tree/cretan_date_palm_tall</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="459.68116" z="637.57313"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="6198"/>
@@ -5874,7 +5874,7 @@
 		</Entity>
 		<Entity uid="839">
 			<Template>gaia/tree/cretan_date_palm_tall</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="698.00483" z="542.26154"/>
 			<Orientation y="-1.03232"/>
 			<Actor seed="35072"/>
@@ -8174,21 +8174,21 @@
 		</Entity>
 		<Entity uid="1286">
 			<Template>gaia/tree/dead</Template>
-			<Player>6</Player>
+			<Player>0</Player>
 			<Position x="1353.56128" z="693.21003"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="44500"/>
 		</Entity>
 		<Entity uid="1287">
 			<Template>gaia/tree/dead</Template>
-			<Player>6</Player>
+			<Player>0</Player>
 			<Position x="1351.8169" z="705.81727"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="15870"/>
 		</Entity>
 		<Entity uid="1288">
 			<Template>gaia/tree/dead</Template>
-			<Player>6</Player>
+			<Player>0</Player>
 			<Position x="1332.56104" z="664.29432"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="60478"/>

--- a/maps/skirmishes/coastline_2.xml
+++ b/maps/skirmishes/coastline_2.xml
@@ -3549,161 +3549,161 @@
 		</Entity>
 		<Entity uid="559">
 			<Template>gaia/tree/bush_badlands</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="384.40427" z="583.15601"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="21830"/>
 		</Entity>
 		<Entity uid="560">
 			<Template>gaia/tree/bush_badlands</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="404.67185" z="557.10114"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="27802"/>
 		</Entity>
 		<Entity uid="561">
 			<Template>gaia/tree/bush_badlands</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="396.12504" z="565.36744"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="27806"/>
 		</Entity>
 		<Entity uid="562">
 			<Template>gaia/tree/bush_badlands</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="397.04755" z="578.198"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="2158"/>
 		</Entity>
 		<Entity uid="563">
 			<Template>gaia/tree/bush_badlands</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="406.43906" z="592.0597"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="38862"/>
 		</Entity>
 		<Entity uid="564">
 			<Template>gaia/tree/bush_badlands</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="414.32987" z="564.44544"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="40472"/>
 		</Entity>
 		<Entity uid="565">
 			<Template>gaia/tree/bush_badlands</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="395.80216" z="607.11994"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="22364"/>
 		</Entity>
 		<Entity uid="566">
 			<Template>gaia/tree/bush_badlands</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="403.77918" z="605.26435"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="35600"/>
 		</Entity>
 		<Entity uid="567">
 			<Template>gaia/tree/bush_badlands</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="393.90409" z="596.94867"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="1490"/>
 		</Entity>
 		<Entity uid="568">
 			<Template>gaia/tree/bush_badlands</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="389.16962" z="568.6457"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="14038"/>
 		</Entity>
 		<Entity uid="569">
 			<Template>gaia/tree/bush_badlands</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="587.59742" z="426.33463"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="29434"/>
 		</Entity>
 		<Entity uid="570">
 			<Template>gaia/tree/bush_badlands</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="596.602" z="439.95136"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="34654"/>
 		</Entity>
 		<Entity uid="571">
 			<Template>gaia/tree/bush_badlands</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="602.40754" z="429.41495"/>
 			<Orientation y="-0.70434"/>
 			<Actor seed="24622"/>
 		</Entity>
 		<Entity uid="572">
 			<Template>gaia/tree/bush_badlands</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="585.93366" z="443.91724"/>
 			<Orientation y="-1.82558"/>
 			<Actor seed="33710"/>
 		</Entity>
 		<Entity uid="573">
 			<Template>gaia/tree/bush_badlands</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="560.78077" z="429.51996"/>
 			<Orientation y="-2.02048"/>
 			<Actor seed="49082"/>
 		</Entity>
 		<Entity uid="574">
 			<Template>gaia/tree/bush_badlands</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="569.2696" z="410.98624"/>
 			<Orientation y="2.74825"/>
 			<Actor seed="34510"/>
 		</Entity>
 		<Entity uid="575">
 			<Template>gaia/tree/bush_badlands</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="611.18165" z="401.00559"/>
 			<Orientation y="0.7748"/>
 			<Actor seed="62288"/>
 		</Entity>
 		<Entity uid="576">
 			<Template>gaia/tree/bush_badlands</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="588.63727" z="410.54123"/>
 			<Orientation y="1.49363"/>
 			<Actor seed="20076"/>
 		</Entity>
 		<Entity uid="577">
 			<Template>gaia/tree/bush_badlands</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="612.5188" z="444.35871"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="304"/>
 		</Entity>
 		<Entity uid="579">
 			<Template>gaia/ore/desert_small</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="568.92786" z="431.58161"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="44534"/>
 		</Entity>
 		<Entity uid="580">
 			<Template>gaia/ore/desert_small</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="609.63263" z="429.16004"/>
 			<Orientation y="1.58123"/>
 			<Actor seed="20706"/>
 		</Entity>
 		<Entity uid="581">
 			<Template>gaia/ore/desert_small</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="393.53266" z="554.00007"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="27014"/>
 		</Entity>
 		<Entity uid="582">
 			<Template>gaia/ore/desert_small</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="408.64078" z="599.76484"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="46652"/>

--- a/maps/skirmishes/euboea_harvest_4.xml
+++ b/maps/skirmishes/euboea_harvest_4.xml
@@ -12894,7 +12894,7 @@
 		</Entity>
 		<Entity uid="2021">
 			<Template>gaia/tree/bush_badlands</Template>
-			<Player>3</Player>
+			<Player>0</Player>
 			<Position x="860.29255" z="741.66816"/>
 			<Orientation y="2.00358"/>
 			<Obstruction group="2067"/>
@@ -13374,7 +13374,7 @@
 		</Entity>
 		<Entity uid="2107">
 			<Template>gaia/tree/bush_badlands</Template>
-			<Player>4</Player>
+			<Player>0</Player>
 			<Position x="836.91749" z="247.14652"/>
 			<Orientation y="3.65351"/>
 			<Actor seed="23494"/>

--- a/maps/skirmishes/fahrenheit_8.xml
+++ b/maps/skirmishes/fahrenheit_8.xml
@@ -11218,7 +11218,7 @@
 		</Entity>
 		<Entity uid="1605">
 			<Template>gaia/ore/alpine_large</Template>
-			<Player>3</Player>
+			<Player>0</Player>
 			<Position x="670.92847" z="654.25208"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="34822"/>

--- a/maps/skirmishes/hispania_4p.xml
+++ b/maps/skirmishes/hispania_4p.xml
@@ -39692,21 +39692,21 @@
 		</Entity>
 		<Entity uid="9572">
 			<Template>gaia/ore/temperate_small</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="1444.80018" z="339.5124"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="14773"/>
 		</Entity>
 		<Entity uid="9573">
 			<Template>gaia/ore/temperate_small</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="1482.82935" z="366.16511"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="18415"/>
 		</Entity>
 		<Entity uid="9574">
 			<Template>gaia/ore/temperate_small</Template>
-			<Player>2</Player>
+			<Player>0</Player>
 			<Position x="1462.58533" z="268.80097"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="49968"/>

--- a/maps/skirmishes/northern_islands_4.xml
+++ b/maps/skirmishes/northern_islands_4.xml
@@ -10749,490 +10749,490 @@
 		</Entity>
 		<Entity uid="1624">
 			<Template>gaia/tree/pine_w</Template>
-			<Player>4</Player>
+			<Player>0</Player>
 			<Position x="807.74622" z="1481.77295"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="50438"/>
 		</Entity>
 		<Entity uid="1625">
 			<Template>gaia/tree/pine_w</Template>
-			<Player>4</Player>
+			<Player>0</Player>
 			<Position x="848.62031" z="1472.72962"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="44062"/>
 		</Entity>
 		<Entity uid="1626">
 			<Template>gaia/tree/pine_w</Template>
-			<Player>4</Player>
+			<Player>0</Player>
 			<Position x="878.4029" z="1464.27625"/>
 			<Orientation y="1.55924"/>
 			<Actor seed="64690"/>
 		</Entity>
 		<Entity uid="1627">
 			<Template>gaia/tree/pine_w</Template>
-			<Player>4</Player>
+			<Player>0</Player>
 			<Position x="912.73823" z="1475.64039"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="64442"/>
 		</Entity>
 		<Entity uid="1628">
 			<Template>gaia/tree/pine_w</Template>
-			<Player>4</Player>
+			<Player>0</Player>
 			<Position x="923.00727" z="1478.58619"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="42280"/>
 		</Entity>
 		<Entity uid="1629">
 			<Template>gaia/tree/pine_w</Template>
-			<Player>4</Player>
+			<Player>0</Player>
 			<Position x="907.8573" z="1486.2599"/>
 			<Orientation y="-1.63076"/>
 			<Actor seed="51888"/>
 		</Entity>
 		<Entity uid="1630">
 			<Template>gaia/tree/pine_w</Template>
-			<Player>4</Player>
+			<Player>0</Player>
 			<Position x="867.69953" z="1476.53492"/>
 			<Orientation y="-1.82154"/>
 			<Actor seed="13450"/>
 		</Entity>
 		<Entity uid="1631">
 			<Template>gaia/tree/pine_w</Template>
-			<Player>4</Player>
+			<Player>0</Player>
 			<Position x="831.0019" z="1479.46802"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="10240"/>
 		</Entity>
 		<Entity uid="1632">
 			<Template>gaia/tree/pine_w</Template>
-			<Player>4</Player>
+			<Player>0</Player>
 			<Position x="814.68866" z="1470.10193"/>
 			<Orientation y="-2.24973"/>
 			<Actor seed="63862"/>
 		</Entity>
 		<Entity uid="1633">
 			<Template>gaia/tree/pine_w</Template>
-			<Player>4</Player>
+			<Player>0</Player>
 			<Position x="780.28541" z="1443.98731"/>
 			<Orientation y="-1.55697"/>
 			<Actor seed="17642"/>
 		</Entity>
 		<Entity uid="1634">
 			<Template>gaia/tree/pine_w</Template>
-			<Player>4</Player>
+			<Player>0</Player>
 			<Position x="744.24653" z="1444.45081"/>
 			<Orientation y="-1.25548"/>
 			<Actor seed="22768"/>
 		</Entity>
 		<Entity uid="1635">
 			<Template>gaia/tree/pine_w</Template>
-			<Player>4</Player>
+			<Player>0</Player>
 			<Position x="725.3907" z="1445.02881"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="6160"/>
 		</Entity>
 		<Entity uid="1636">
 			<Template>gaia/tree/pine_w</Template>
-			<Player>4</Player>
+			<Player>0</Player>
 			<Position x="728.13837" z="1454.44898"/>
 			<Orientation y="0.12331"/>
 			<Actor seed="52728"/>
 		</Entity>
 		<Entity uid="1637">
 			<Template>gaia/tree/pine_w</Template>
-			<Player>4</Player>
+			<Player>0</Player>
 			<Position x="730.24201" z="1470.82972"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="41934"/>
 		</Entity>
 		<Entity uid="1638">
 			<Template>gaia/tree/pine_w</Template>
-			<Player>4</Player>
+			<Player>0</Player>
 			<Position x="745.31257" z="1453.83655"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="18296"/>
 		</Entity>
 		<Entity uid="1639">
 			<Template>gaia/tree/pine_w</Template>
-			<Player>4</Player>
+			<Player>0</Player>
 			<Position x="746.13855" z="1450.52808"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="18780"/>
 		</Entity>
 		<Entity uid="1640">
 			<Template>gaia/tree/pine_w</Template>
-			<Player>4</Player>
+			<Player>0</Player>
 			<Position x="752.04725" z="1448.39405"/>
 			<Orientation y="2.57175"/>
 			<Actor seed="59384"/>
 		</Entity>
 		<Entity uid="1641">
 			<Template>gaia/tree/pine_w</Template>
-			<Player>4</Player>
+			<Player>0</Player>
 			<Position x="762.26746" z="1440.09766"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="24234"/>
 		</Entity>
 		<Entity uid="1642">
 			<Template>gaia/tree/pine_w</Template>
-			<Player>4</Player>
+			<Player>0</Player>
 			<Position x="729.7353" z="1401.64966"/>
 			<Orientation y="1.38442"/>
 			<Actor seed="50398"/>
 		</Entity>
 		<Entity uid="1643">
 			<Template>gaia/tree/pine_w</Template>
-			<Player>4</Player>
+			<Player>0</Player>
 			<Position x="746.41712" z="1406.34913"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="28096"/>
 		</Entity>
 		<Entity uid="1644">
 			<Template>gaia/tree/pine_w</Template>
-			<Player>4</Player>
+			<Player>0</Player>
 			<Position x="817.5926" z="1489.01307"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="45440"/>
 		</Entity>
 		<Entity uid="1645">
 			<Template>gaia/tree/pine_w</Template>
-			<Player>4</Player>
+			<Player>0</Player>
 			<Position x="813.11109" z="1480.40784"/>
 			<Orientation y="-1.75678"/>
 			<Actor seed="14450"/>
 		</Entity>
 		<Entity uid="1646">
 			<Template>gaia/tree/pine_w</Template>
-			<Player>4</Player>
+			<Player>0</Player>
 			<Position x="753.27637" z="1490.50562"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="1250"/>
 		</Entity>
 		<Entity uid="1647">
 			<Template>gaia/tree/pine_w</Template>
-			<Player>4</Player>
+			<Player>0</Player>
 			<Position x="777.65992" z="1483.63318"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="62504"/>
 		</Entity>
 		<Entity uid="1648">
 			<Template>gaia/tree/pine_w</Template>
-			<Player>4</Player>
+			<Player>0</Player>
 			<Position x="775.7176" z="1491.51783"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="16240"/>
 		</Entity>
 		<Entity uid="1649">
 			<Template>gaia/tree/pine_w</Template>
-			<Player>4</Player>
+			<Player>0</Player>
 			<Position x="775.71387" z="1500.80054"/>
 			<Orientation y="1.10097"/>
 			<Actor seed="19888"/>
 		</Entity>
 		<Entity uid="1650">
 			<Template>gaia/tree/pine_w</Template>
-			<Player>4</Player>
+			<Player>0</Player>
 			<Position x="795.95344" z="1503.45594"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="8322"/>
 		</Entity>
 		<Entity uid="1651">
 			<Template>gaia/tree/pine_w</Template>
-			<Player>4</Player>
+			<Player>0</Player>
 			<Position x="808.88538" z="1506.06336"/>
 			<Orientation y="1.83941"/>
 			<Actor seed="50616"/>
 		</Entity>
 		<Entity uid="1652">
 			<Template>gaia/tree/pine_w</Template>
-			<Player>4</Player>
+			<Player>0</Player>
 			<Position x="843.85328" z="1493.06885"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="47608"/>
 		</Entity>
 		<Entity uid="1653">
 			<Template>gaia/tree/pine_w</Template>
-			<Player>4</Player>
+			<Player>0</Player>
 			<Position x="859.96204" z="1495.6858"/>
 			<Orientation y="1.82807"/>
 			<Actor seed="64238"/>
 		</Entity>
 		<Entity uid="1654">
 			<Template>gaia/tree/pine_w</Template>
-			<Player>4</Player>
+			<Player>0</Player>
 			<Position x="912.29395" z="1491.80311"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="708"/>
 		</Entity>
 		<Entity uid="1655">
 			<Template>gaia/tree/pine_w</Template>
-			<Player>4</Player>
+			<Player>0</Player>
 			<Position x="917.95765" z="1490.19935"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="40820"/>
 		</Entity>
 		<Entity uid="1656">
 			<Template>gaia/tree/pine_w</Template>
-			<Player>4</Player>
+			<Player>0</Player>
 			<Position x="912.63868" z="1484.86084"/>
 			<Orientation y="-1.75109"/>
 			<Actor seed="61354"/>
 		</Entity>
 		<Entity uid="1657">
 			<Template>gaia/tree/pine_w</Template>
-			<Player>4</Player>
+			<Player>0</Player>
 			<Position x="787.9087" z="1437.99793"/>
 			<Orientation y="-2.36333"/>
 			<Actor seed="17304"/>
 		</Entity>
 		<Entity uid="1658">
 			<Template>gaia/tree/pine_w</Template>
-			<Player>4</Player>
+			<Player>0</Player>
 			<Position x="738.11048" z="1388.5348"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="54280"/>
 		</Entity>
 		<Entity uid="1659">
 			<Template>gaia/tree/pine_w</Template>
-			<Player>4</Player>
+			<Player>0</Player>
 			<Position x="723.59382" z="1376.11988"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="61548"/>
 		</Entity>
 		<Entity uid="1660">
 			<Template>gaia/tree/pine_w</Template>
-			<Player>4</Player>
+			<Player>0</Player>
 			<Position x="720.11072" z="1378.95252"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="23294"/>
 		</Entity>
 		<Entity uid="1661">
 			<Template>gaia/tree/pine_w</Template>
-			<Player>4</Player>
+			<Player>0</Player>
 			<Position x="721.26355" z="1387.81739"/>
 			<Orientation y="-0.15152"/>
 			<Actor seed="57702"/>
 		</Entity>
 		<Entity uid="1662">
 			<Template>gaia/tree/pine_w</Template>
-			<Player>4</Player>
+			<Player>0</Player>
 			<Position x="717.19416" z="1447.48011"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="27584"/>
 		</Entity>
 		<Entity uid="1663">
 			<Template>gaia/tree/pine_w</Template>
-			<Player>4</Player>
+			<Player>0</Player>
 			<Position x="731.9527" z="1478.3628"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="42078"/>
 		</Entity>
 		<Entity uid="1664">
 			<Template>gaia/tree/pine_w</Template>
-			<Player>4</Player>
+			<Player>0</Player>
 			<Position x="725.79041" z="1484.72144"/>
 			<Orientation y="0.24498"/>
 			<Actor seed="25178"/>
 		</Entity>
 		<Entity uid="1665">
 			<Template>gaia/tree/pine_w</Template>
-			<Player>4</Player>
+			<Player>0</Player>
 			<Position x="726.20093" z="1504.35962"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="42052"/>
 		</Entity>
 		<Entity uid="1666">
 			<Template>gaia/tree/pine_w</Template>
-			<Player>4</Player>
+			<Player>0</Player>
 			<Position x="753.67676" z="1505.51673"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="53448"/>
 		</Entity>
 		<Entity uid="1667">
 			<Template>gaia/tree/pine_w</Template>
-			<Player>4</Player>
+			<Player>0</Player>
 			<Position x="747.7555" z="1497.24366"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="49886"/>
 		</Entity>
 		<Entity uid="1668">
 			<Template>gaia/tree/bush_badlands</Template>
-			<Player>4</Player>
+			<Player>0</Player>
 			<Position x="875.87678" z="1422.3949"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="20512"/>
 		</Entity>
 		<Entity uid="1669">
 			<Template>gaia/tree/bush_badlands</Template>
-			<Player>4</Player>
+			<Player>0</Player>
 			<Position x="867.76752" z="1424.73255"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="19204"/>
 		</Entity>
 		<Entity uid="1670">
 			<Template>gaia/tree/bush_badlands</Template>
-			<Player>4</Player>
+			<Player>0</Player>
 			<Position x="858.92121" z="1432.24781"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="21534"/>
 		</Entity>
 		<Entity uid="1671">
 			<Template>gaia/tree/bush_badlands</Template>
-			<Player>4</Player>
+			<Player>0</Player>
 			<Position x="869.50007" z="1440.82544"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="31456"/>
 		</Entity>
 		<Entity uid="1672">
 			<Template>gaia/tree/bush_badlands</Template>
-			<Player>4</Player>
+			<Player>0</Player>
 			<Position x="890.58924" z="1424.67042"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="12864"/>
 		</Entity>
 		<Entity uid="1673">
 			<Template>gaia/tree/bush_badlands</Template>
-			<Player>4</Player>
+			<Player>0</Player>
 			<Position x="1321.4115" z="851.31476"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="13198"/>
 		</Entity>
 		<Entity uid="1674">
 			<Template>gaia/tree/bush_badlands</Template>
-			<Player>4</Player>
+			<Player>0</Player>
 			<Position x="1312.66114" z="850.79773"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="14914"/>
 		</Entity>
 		<Entity uid="1675">
 			<Template>gaia/tree/bush_badlands</Template>
-			<Player>4</Player>
+			<Player>0</Player>
 			<Position x="1303.62427" z="853.64643"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="936"/>
 		</Entity>
 		<Entity uid="1676">
 			<Template>gaia/tree/bush_badlands</Template>
-			<Player>4</Player>
+			<Player>0</Player>
 			<Position x="1302.16968" z="854.23066"/>
 			<Orientation y="1.91572"/>
 			<Actor seed="38614"/>
 		</Entity>
 		<Entity uid="1677">
 			<Template>gaia/tree/bush_badlands</Template>
-			<Player>4</Player>
+			<Player>0</Player>
 			<Position x="1312.08375" z="851.69874"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="63374"/>
 		</Entity>
 		<Entity uid="1678">
 			<Template>gaia/tree/bush_badlands</Template>
-			<Player>4</Player>
+			<Player>0</Player>
 			<Position x="1321.19996" z="854.90204"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="19832"/>
 		</Entity>
 		<Entity uid="1679">
 			<Template>gaia/tree/bush_badlands</Template>
-			<Player>4</Player>
+			<Player>0</Player>
 			<Position x="1325.38843" z="860.02485"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="3808"/>
 		</Entity>
 		<Entity uid="1680">
 			<Template>gaia/tree/bush_badlands</Template>
-			<Player>4</Player>
+			<Player>0</Player>
 			<Position x="1317.92115" z="862.8849"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="32534"/>
 		</Entity>
 		<Entity uid="1681">
 			<Template>gaia/tree/bush_badlands</Template>
-			<Player>4</Player>
+			<Player>0</Player>
 			<Position x="1311.1338" z="861.28663"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="38796"/>
 		</Entity>
 		<Entity uid="1682">
 			<Template>gaia/tree/bush_badlands</Template>
-			<Player>4</Player>
+			<Player>0</Player>
 			<Position x="1304.54566" z="860.81946"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="65481"/>
 		</Entity>
 		<Entity uid="1683">
 			<Template>gaia/tree/bush_badlands</Template>
-			<Player>4</Player>
+			<Player>0</Player>
 			<Position x="1298.9231" z="860.98334"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="27544"/>
 		</Entity>
 		<Entity uid="1684">
 			<Template>gaia/fruit/berry_01</Template>
-			<Player>4</Player>
+			<Player>0</Player>
 			<Position x="1323.74988" z="876.81391"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="48086"/>
 		</Entity>
 		<Entity uid="1685">
 			<Template>gaia/fruit/berry_01</Template>
-			<Player>4</Player>
+			<Player>0</Player>
 			<Position x="1331.55311" z="876.2165"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="39166"/>
 		</Entity>
 		<Entity uid="1686">
 			<Template>gaia/fruit/berry_01</Template>
-			<Player>4</Player>
+			<Player>0</Player>
 			<Position x="1327.15052" z="887.04975"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="35352"/>
 		</Entity>
 		<Entity uid="1687">
 			<Template>gaia/fruit/berry_01</Template>
-			<Player>4</Player>
+			<Player>0</Player>
 			<Position x="1332.89405" z="882.10132"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="65389"/>
 		</Entity>
 		<Entity uid="1688">
 			<Template>gaia/fruit/berry_01</Template>
-			<Player>4</Player>
+			<Player>0</Player>
 			<Position x="1324.86377" z="880.1667"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="40558"/>
 		</Entity>
 		<Entity uid="1689">
 			<Template>gaia/fruit/berry_01</Template>
-			<Player>4</Player>
+			<Player>0</Player>
 			<Position x="899.66822" z="1412.97437"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="47568"/>
 		</Entity>
 		<Entity uid="1690">
 			<Template>gaia/fruit/berry_01</Template>
-			<Player>4</Player>
+			<Player>0</Player>
 			<Position x="908.76252" z="1409.44703"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="7764"/>
 		</Entity>
 		<Entity uid="1691">
 			<Template>gaia/fruit/berry_01</Template>
-			<Player>4</Player>
+			<Player>0</Player>
 			<Position x="900.55994" z="1404.17212"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="27938"/>
 		</Entity>
 		<Entity uid="1692">
 			<Template>gaia/fruit/berry_01</Template>
-			<Player>4</Player>
+			<Player>0</Player>
 			<Position x="906.79859" z="1418.76465"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="43658"/>
 		</Entity>
 		<Entity uid="1693">
 			<Template>gaia/fruit/berry_01</Template>
-			<Player>4</Player>
+			<Player>0</Player>
 			<Position x="891.74225" z="1409.53687"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="6206"/>

--- a/maps/skirmishes/the_valley_of_forgotten_temple_4.xml
+++ b/maps/skirmishes/the_valley_of_forgotten_temple_4.xml
@@ -34052,301 +34052,301 @@
 		</Entity>
 		<Entity uid="4878">
 			<Template>gaia/tree/palm_areca</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="698.35163" z="869.23914"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="34851"/>
 		</Entity>
 		<Entity uid="4879">
 			<Template>gaia/tree/palm_areca</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="677.90613" z="870.18946"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="23071"/>
 		</Entity>
 		<Entity uid="4880">
 			<Template>gaia/tree/palm_areca</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="663.6656" z="854.2605"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="38976"/>
 		</Entity>
 		<Entity uid="4881">
 			<Template>gaia/tree/palm_areca</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="654.16132" z="840.30549"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="38976"/>
 		</Entity>
 		<Entity uid="4882">
 			<Template>gaia/tree/palm_areca</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="647.07251" z="822.34247"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="38976"/>
 		</Entity>
 		<Entity uid="4883">
 			<Template>gaia/tree/palm_areca</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="640.69599" z="803.85267"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="61126"/>
 		</Entity>
 		<Entity uid="4884">
 			<Template>gaia/tree/palm_areca</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="633.10724" z="783.66279"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="61126"/>
 		</Entity>
 		<Entity uid="4885">
 			<Template>gaia/tree/palm_areca</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="666.47168" z="812.27936"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="61126"/>
 		</Entity>
 		<Entity uid="4886">
 			<Template>gaia/tree/palm_areca</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="681.35389" z="829.61646"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="17957"/>
 		</Entity>
 		<Entity uid="4887">
 			<Template>gaia/tree/palm_areca</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="706.16926" z="839.0008"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="17957"/>
 		</Entity>
 		<Entity uid="4888">
 			<Template>gaia/tree/palm_areca</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="761.87397" z="786.8332"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="17957"/>
 		</Entity>
 		<Entity uid="4889">
 			<Template>gaia/tree/palm_areca</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="759.1142" z="755.08515"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="50405"/>
 		</Entity>
 		<Entity uid="4890">
 			<Template>gaia/tree/palm_areca</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="759.94251" z="698.84528"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="50405"/>
 		</Entity>
 		<Entity uid="4891">
 			<Template>gaia/tree/palm_areca</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="720.70881" z="674.03113"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="18025"/>
 		</Entity>
 		<Entity uid="4892">
 			<Template>gaia/tree/palm_areca</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="705.56904" z="689.38697"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="18025"/>
 		</Entity>
 		<Entity uid="4893">
 			<Template>gaia/tree/palm_areca</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="698.66224" z="700.64148"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="59322"/>
 		</Entity>
 		<Entity uid="4894">
 			<Template>gaia/tree/palm_areca</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="692.04767" z="706.22974"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="59322"/>
 		</Entity>
 		<Entity uid="4895">
 			<Template>gaia/tree/palm_areca</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="667.04743" z="715.53681"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="59322"/>
 		</Entity>
 		<Entity uid="4896">
 			<Template>gaia/tree/palm_areca</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="645.95911" z="686.47547"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="8255"/>
 		</Entity>
 		<Entity uid="4897">
 			<Template>gaia/tree/palm_areca</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="640.67835" z="674.1902"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="8255"/>
 		</Entity>
 		<Entity uid="4898">
 			<Template>gaia/tree/palm_areca</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="635.14985" z="666.66346"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="42168"/>
 		</Entity>
 		<Entity uid="4899">
 			<Template>gaia/tree/palm_areca</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="627.06922" z="669.96027"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="42168"/>
 		</Entity>
 		<Entity uid="4900">
 			<Template>gaia/tree/palm_areca</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="630.51288" z="667.74604"/>
 			<Orientation y="2.14222"/>
 			<Actor seed="42168"/>
 		</Entity>
 		<Entity uid="4901">
 			<Template>gaia/tree/palm_areca</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="651.94098" z="644.2403"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="42168"/>
 		</Entity>
 		<Entity uid="4902">
 			<Template>gaia/tree/palm_areca</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="660.97767" z="638.42994"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="34358"/>
 		</Entity>
 		<Entity uid="4903">
 			<Template>gaia/tree/palm_areca</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="672.72864" z="620.73914"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="34358"/>
 		</Entity>
 		<Entity uid="4904">
 			<Template>gaia/tree/palm_areca</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="665.73902" z="592.11078"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="34358"/>
 		</Entity>
 		<Entity uid="4905">
 			<Template>gaia/tree/palm_areca</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="651.79041" z="552.16041"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="34358"/>
 		</Entity>
 		<Entity uid="4906">
 			<Template>gaia/tree/palm_areca</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="641.96552" z="522.61463"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="61474"/>
 		</Entity>
 		<Entity uid="4907">
 			<Template>gaia/tree/palm_areca</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="662.05549" z="534.08216"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="61474"/>
 		</Entity>
 		<Entity uid="4908">
 			<Template>gaia/tree/palm_areca</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="671.52875" z="561.13123"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="61474"/>
 		</Entity>
 		<Entity uid="4909">
 			<Template>gaia/tree/palm_areca</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="692.95655" z="586.13386"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="61474"/>
 		</Entity>
 		<Entity uid="4910">
 			<Template>gaia/tree/palm_areca</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="704.29328" z="592.11976"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="55989"/>
 		</Entity>
 		<Entity uid="4911">
 			<Template>gaia/tree/palm_areca</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="719.35938" z="580.4673"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="55989"/>
 		</Entity>
 		<Entity uid="4912">
 			<Template>gaia/tree/palm_areca</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="732.56153" z="580.24402"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="55989"/>
 		</Entity>
 		<Entity uid="4913">
 			<Template>gaia/tree/palm_areca</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="736.10242" z="596.97522"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="51179"/>
 		</Entity>
 		<Entity uid="4914">
 			<Template>gaia/tree/tamarix</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="690.17817" z="838.11799"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="9500"/>
 		</Entity>
 		<Entity uid="4915">
 			<Template>gaia/tree/tamarix</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="681.84742" z="824.87531"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="26448"/>
 		</Entity>
 		<Entity uid="4916">
 			<Template>gaia/tree/tamarix</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="661.58222" z="822.37073"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="8373"/>
 		</Entity>
 		<Entity uid="4917">
 			<Template>gaia/tree/tamarix</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="646.21155" z="786.83503"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="8373"/>
 		</Entity>
 		<Entity uid="4918">
 			<Template>gaia/tree/tamarix</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="629.6009" z="762.93238"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="21054"/>
 		</Entity>
 		<Entity uid="4919">
 			<Template>gaia/tree/tamarix</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="618.21393" z="771.25855"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="6256"/>
 		</Entity>
 		<Entity uid="4920">
 			<Template>gaia/tree/tamarix</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="609.78052" z="779.6532"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="6256"/>
@@ -34710,189 +34710,189 @@
 		</Entity>
 		<Entity uid="4972">
 			<Template>gaia/treasure/metal</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="715.5398" z="733.98194"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="36556"/>
 		</Entity>
 		<Entity uid="4973">
 			<Template>gaia/treasure/metal</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="717.8949" z="732.04334"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="35179"/>
 		</Entity>
 		<Entity uid="4974">
 			<Template>gaia/treasure/metal</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="715.76557" z="728.60566"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="35179"/>
 		</Entity>
 		<Entity uid="4975">
 			<Template>gaia/treasure/metal</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="710.40174" z="729.78144"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="32691"/>
 		</Entity>
 		<Entity uid="4976">
 			<Template>gaia/treasure/metal</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="710.72352" z="724.85224"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="32691"/>
 		</Entity>
 		<Entity uid="4977">
 			<Template>gaia/treasure/metal</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="715.42676" z="723.27027"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="3131"/>
 		</Entity>
 		<Entity uid="4978">
 			<Template>gaia/treasure/metal_persian_small</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="702.38013" z="732.25355"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="29551"/>
 		</Entity>
 		<Entity uid="4979">
 			<Template>gaia/treasure/stone</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="722.81476" z="721.873"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="45600"/>
 		</Entity>
 		<Entity uid="4980">
 			<Template>gaia/treasure/stone</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="733.65351" z="717.50281"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="33787"/>
 		</Entity>
 		<Entity uid="4981">
 			<Template>gaia/treasure/stone</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="775.59021" z="766.71283"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="39638"/>
 		</Entity>
 		<Entity uid="4982">
 			<Template>gaia/treasure/stone</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="756.91767" z="797.53974"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="32587"/>
 		</Entity>
 		<Entity uid="4983">
 			<Template>gaia/treasure/stone</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="829.5652" z="837.91749"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="28453"/>
 		</Entity>
 		<Entity uid="4984">
 			<Template>gaia/treasure/stone</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="744.67273" z="903.04493"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="63197"/>
 		</Entity>
 		<Entity uid="4985">
 			<Template>gaia/treasure/stone</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="716.9662" z="895.07337"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="18499"/>
 		</Entity>
 		<Entity uid="4986">
 			<Template>gaia/treasure/stone</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="628.6786" z="834.21064"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="19532"/>
 		</Entity>
 		<Entity uid="4987">
 			<Template>gaia/treasure/stone_pile_sandstone</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="853.53461" z="811.50525"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="23371"/>
 		</Entity>
 		<Entity uid="4988">
 			<Template>gaia/treasure/stone_pile_sandstone</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="845.75104" z="747.32477"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="29553"/>
 		</Entity>
 		<Entity uid="4989">
 			<Template>gaia/treasure/stone_pile_sandstone</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="781.60138" z="814.62018"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="2918"/>
 		</Entity>
 		<Entity uid="4990">
 			<Template>gaia/treasure/wood_lumber</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="853.31623" z="796.378"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="12778"/>
 		</Entity>
 		<Entity uid="4991">
 			<Template>gaia/treasure/wood_lumber</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="842.00532" z="760.96338"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="61536"/>
 		</Entity>
 		<Entity uid="4992">
 			<Template>gaia/treasure/wood_lumber</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="835.5362" z="746.45533"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="36861"/>
 		</Entity>
 		<Entity uid="4993">
 			<Template>gaia/treasure/wood_lumber</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="825.68738" z="797.26496"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="36861"/>
 		</Entity>
 		<Entity uid="4994">
 			<Template>gaia/treasure/food_crate</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="833.89148" z="787.77686"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="3472"/>
 		</Entity>
 		<Entity uid="4995">
 			<Template>gaia/treasure/food_crate</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="822.41401" z="792.2292"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="53669"/>
 		</Entity>
 		<Entity uid="4996">
 			<Template>gaia/treasure/food_crate</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="814.73139" z="784.48078"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="49113"/>
 		</Entity>
 		<Entity uid="4997">
 			<Template>gaia/treasure/food_crate</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="789.69941" z="817.21985"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="4521"/>
 		</Entity>
 		<Entity uid="4998">
 			<Template>gaia/treasure/food_crate</Template>
-			<Player>1</Player>
+			<Player>0</Player>
 			<Position x="779.11292" z="809.98505"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="40823"/>
@@ -35914,7 +35914,7 @@
 		</Entity>
 		<Entity uid="5146">
 			<Template>gaia/fruit/berry_01</Template>
-			<Player>3</Player>
+			<Player>0</Player>
 			<Position x="1512.09681" z="663.5442"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="36074"/>
@@ -35942,7 +35942,7 @@
 		</Entity>
 		<Entity uid="5150">
 			<Template>gaia/fruit/berry_01</Template>
-			<Player>3</Player>
+			<Player>0</Player>
 			<Position x="1485.48658" z="650.17109"/>
 			<Orientation y="2.35621"/>
 			<Actor seed="16338"/>


### PR DESCRIPTION
#### description
- some templates should not belong to a specific player, e.g. fish, tree, ...
- this patch replaces the player number with a zero
  - Ref: [D4123](https://code.wildfiregames.com/D4123)

---

- can be added to the github workflow to check new files for this problem (later, maybe)
  - python script: [#6688](https://trac.wildfiregames.com/ticket/6688)
  - or using bash with grep and sed
