### PR TITLE
checkrefs.yml: migrate tj-actions v35->41

### DIFF
--- a/.github/workflows/checkrefs.yml
+++ b/.github/workflows/checkrefs.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: tj-actions/changed-files@v35
+      - uses: tj-actions/changed-files@v41
         id: changed-files-glob
         with:
           separator: ','


### PR DESCRIPTION
For https://github.com/0ad-matters/community-maps-2/security/dependabot/1